### PR TITLE
Sync j/ plugins: J-ABS 4.7.2 and J-ABS-AllyAI 2.1.2

### DIFF
--- a/chef-adventure/js/plugins/j/abs/J-ABS.js
+++ b/chef-adventure/js/plugins/j/abs/J-ABS.js
@@ -2076,15 +2076,16 @@ class JABS_AI
 
   /**
    * Decides an action based on this battler's AI, the target, and the given available skills.
+   * {@link JABS_EnemyAI} and {@link JABS_AllyAI} override this and return exactly zero or one skill id as a list.
    * @param {JABS_Battler} user The battler of the AI deciding a skill.
    * @param {JABS_Battler} target The target battler to decide an action against.
    * @param {number[]} availableSkills A collection of all skill ids to potentially pick from.
-   * @returns {number|null} The skill id chosen to use, or null if none were valid choices for this AI.
+   * @returns {number[]} Empty stub; subclasses return `[]` or `[skillId]`.
    */
   // eslint-disable-next-line no-unused-vars
   decideAction(user, target, availableSkills)
   {
-    return 0;
+    return [];
   }
 
   /**
@@ -10213,7 +10214,7 @@ class JABS_EnemyAI
    * @param {JABS_Battler} user The battler of the AI deciding a skill.
    * @param {JABS_Battler} target The target battler to decide an action against.
    * @param {number[]} availableSkills A collection of all skill ids to potentially pick from.
-   * @returns {number|null} The skill id chosen to use, or null if none were valid choices for this AI.
+   * @returns {number[]} Exactly one skill id, or empty when no valid choice exists.
    */
   decideAction(user, target, availableSkills)
   {
@@ -10237,23 +10238,23 @@ class JABS_EnemyAI
       console.warn('a battler with the "reckless" trait was found with no skills.', user);
     }
 
-    // support layer — each method falls through (returns 0/null) when nothing is needed.
+    // support layer — each method returns [] when nothing is needed for that trait.
     if (cleanser)
     {
-      const id = this.decideCleanserAction(user, usableSkills);
-      if (id) return id;
+      const picked = this.decideCleanserAction(user, usableSkills);
+      if (picked.length) return picked;
     }
 
     if (healer)
     {
-      const id = this.decideHealerAction(user, usableSkills);
-      if (id) return id;
+      const picked = this.decideHealerAction(user, usableSkills);
+      if (picked.length) return picked;
     }
 
     if (buffer)
     {
-      const id = this.decideBufferAction(user, usableSkills);
-      if (id) return id;
+      const picked = this.decideBufferAction(user, usableSkills);
+      if (picked.length) return picked;
     }
 
     // berserker overrides normal attack strategy at low HP.
@@ -10274,21 +10275,32 @@ class JABS_EnemyAI
 
   //region support wrappers
   /**
+   * Wraps a base support helper result (0 means none) as a uniform skill-id list.
+   * @param {number} skillId The skill id from {@link JABS_AI} support methods, or 0.
+   * @returns {number[]}
+   */
+  wrapSupportSkillId(skillId)
+  {
+    if (!skillId) return [];
+    return [ skillId ];
+  }
+
+  /**
    * Handles the combo check and delegates to {@link #decideCleansing} from the base class.
    * @param {JABS_Battler} user The battler choosing the skill.
    * @param {number[]} usableSkills The currently available skills.
-   * @returns {number} A skill id if cleansing is warranted, or 0 if not.
+   * @returns {number[]} One skill id if cleansing is warranted, or empty if not.
    */
   decideCleanserAction(user, usableSkills)
   {
     if (this.shouldFollowWithCombo(user))
     {
-      return this.followWithCombo(user);
+      return [ this.followWithCombo(user) ];
     }
 
-    if (!usableSkills.length) return 0;
+    if (!usableSkills.length) return [];
 
-    return this.decideCleansing(user, usableSkills);
+    return this.wrapSupportSkillId(this.decideCleansing(user, usableSkills));
   }
 
   /**
@@ -10296,38 +10308,38 @@ class JABS_EnemyAI
    * The healing threshold is widened when the healer is reckless.
    * @param {JABS_Battler} user The battler choosing the skill.
    * @param {number[]} usableSkills The currently available skills.
-   * @returns {number} A skill id if healing is warranted, or 0 if not.
+   * @returns {number[]} One skill id if healing is warranted, or empty if not.
    */
   decideHealerAction(user, usableSkills)
   {
     if (this.shouldFollowWithCombo(user))
     {
-      return this.followWithCombo(user);
+      return [ this.followWithCombo(user) ];
     }
 
-    if (!usableSkills.length) return 0;
+    if (!usableSkills.length) return [];
 
     // reckless healers treat a wider threshold as "low".
     const threshold = this.reckless ? 0.9 : 0.6;
-    return this.decideHealing(user, usableSkills, threshold);
+    return this.wrapSupportSkillId(this.decideHealing(user, usableSkills, threshold));
   }
 
   /**
    * Handles the combo check and delegates to {@link #decideBuffing} from the base class.
    * @param {JABS_Battler} user The battler choosing the skill.
    * @param {number[]} usableSkills The currently available skills.
-   * @returns {number} A skill id if buffing is warranted, or 0 if not.
+   * @returns {number[]} One skill id if buffing is warranted, or empty if not.
    */
   decideBufferAction(user, usableSkills)
   {
     if (this.shouldFollowWithCombo(user))
     {
-      return this.followWithCombo(user);
+      return [ this.followWithCombo(user) ];
     }
 
-    if (!usableSkills.length) return 0;
+    if (!usableSkills.length) return [];
 
-    return this.decideBuffing(user, usableSkills);
+    return this.wrapSupportSkillId(this.decideBuffing(user, usableSkills));
   }
   //endregion support wrappers
 
@@ -10338,19 +10350,20 @@ class JABS_EnemyAI
    * @param {JABS_Battler} user The battler choosing the skill.
    * @param {number[]} usableSkills The currently available skills.
    * @param {JABS_Battler} target The current target.
-   * @returns {number}
+   * @returns {number[]}
    */
   decideBerserkerAction(user, usableSkills, target)
   {
     if (this.shouldFollowWithCombo(user))
     {
-      return this.followWithCombo(user);
+      return [ this.followWithCombo(user) ];
     }
 
-    if (!usableSkills.length) return user.getEnemyBasicAttack();
+    if (!usableSkills.length) return [ user.getEnemyBasicAttack() ];
 
     const strongestSkillId = this.determineStrongestSkill(usableSkills, user, target);
-    return strongestSkillId || user.getEnemyBasicAttack();
+    if (strongestSkillId) return [ strongestSkillId ];
+    return [ user.getEnemyBasicAttack() ];
   }
 
   /**
@@ -10369,16 +10382,16 @@ class JABS_EnemyAI
    * Applies careful/executor/tactical filters in sequence, then calls memory-influenced selection.
    * @param {JABS_Battler} user The battler to decide the skill for.
    * @param {number[]} usableSkills The available skills to use.
-   * @returns {number}
+   * @returns {number[]}
    */
   decideAttackAction(user, usableSkills)
   {
     if (this.shouldFollowWithCombo(user))
     {
-      return this.followWithCombo(user);
+      return [ this.followWithCombo(user) ];
     }
 
-    if (!usableSkills.length) return null;
+    if (!usableSkills.length) return [];
 
     const target = user.getTarget();
     let filtered = usableSkills;
@@ -10401,7 +10414,7 @@ class JABS_EnemyAI
       filtered = this.filterForTacticalSkills(filtered, user, target);
     }
 
-    return this.decideFromNoneToManySkills(user, filtered);
+    return [ this.decideFromNoneToManySkills(user, filtered) ];
   }
 
   /**
@@ -10431,18 +10444,18 @@ class JABS_EnemyAI
    * RNG decides this AI-controlled battler's fate.
    * @param {JABS_Battler} user The battler of the AI deciding the action.
    * @param {number[]} usableSkills The possible skills this AI can choose from.
-   * @returns {number} The decided skill id.
+   * @returns {number[]}
    */
   decideGenericAction(user, usableSkills)
   {
     if (this.shouldFollowWithCombo(user))
     {
-      return this.followWithCombo(user);
+      return [ this.followWithCombo(user) ];
     }
 
     if (!usableSkills.length)
     {
-      return user.getEnemyBasicAttack();
+      return [ user.getEnemyBasicAttack() ];
     }
 
     const randomIndex = Math.randomInt(usableSkills.length);
@@ -10451,10 +10464,10 @@ class JABS_EnemyAI
     // 50% chance of just using the basic attack instead.
     if (Math.randomInt(2) === 0)
     {
-      return user.getEnemyBasicAttack();
+      return [ user.getEnemyBasicAttack() ];
     }
 
-    return randomSkillId;
+    return [ randomSkillId ];
   }
   //endregion attack actions
 
@@ -10483,11 +10496,11 @@ class JABS_EnemyAI
       follower.setLeader(leader.getUuid());
     }
 
-    const decidedFollowerSkillId = this.decideActionForFollower(leader, follower);
+    const decidedFollowerPicks = this.decideActionForFollower(leader, follower);
 
-    if (this.isSkillIdValid(decidedFollowerSkillId))
+    if (decidedFollowerPicks.length && this.isSkillIdValid(decidedFollowerPicks[0]))
     {
-      follower.setLeaderDecidedAction(decidedFollowerSkillId);
+      follower.setLeaderDecidedAction(decidedFollowerPicks[0]);
     }
   }
 
@@ -10519,19 +10532,19 @@ class JABS_EnemyAI
    * Decides an action for the designated follower based on the leader's AI traits.
    * @param {JABS_Battler} leaderBattler The leader deciding the action.
    * @param {JABS_Battler} followerBattler The follower executing the decided action.
-   * @returns {number} The skill id for the follower to perform.
+   * @returns {number[]}
    */
   decideActionForFollower(leaderBattler, followerBattler)
   {
     if (this.shouldFollowWithCombo(followerBattler))
     {
-      return this.followWithCombo(followerBattler);
+      return [ this.followWithCombo(followerBattler) ];
     }
 
     const basicAttackSkillId = followerBattler.getEnemyBasicAttack();
     let skillsToUse = followerBattler.getSkillIdsFromEnemy();
 
-    if (!skillsToUse.length) return basicAttackSkillId;
+    if (!skillsToUse.length) return [ basicAttackSkillId ];
 
     const { healer, careful, executor } = this;
 
@@ -10548,19 +10561,19 @@ class JABS_EnemyAI
       skillsToUse = this.decideAttackAction(leaderBattler, skillsToUse);
     }
 
-    if (!skillsToUse || (Array.isArray(skillsToUse) && skillsToUse.length === 0))
+    if (skillsToUse.length === 0)
     {
-      return basicAttackSkillId;
+      return [ basicAttackSkillId ];
     }
 
-    const chosenSkillId = Array.isArray(skillsToUse) ? skillsToUse.at(0) : skillsToUse;
+    const chosenSkillId = skillsToUse.at(0);
 
     const followerGameBattler = followerBattler.getBattler();
     const skill = followerGameBattler.skill(chosenSkillId);
 
-    if (!followerGameBattler.canPaySkillCost(skill)) return basicAttackSkillId;
+    if (!followerGameBattler.canPaySkillCost(skill)) return [ basicAttackSkillId ];
 
-    return chosenSkillId;
+    return [ chosenSkillId ];
   }
 
   /**
@@ -10730,7 +10743,8 @@ class JABS_EnemyAI
       bestSkillId = biggestHealSkill;
     }
 
-    return bestSkillId;
+    if (!bestSkillId) return [];
+    return [ bestSkillId ];
   }
   //endregion leader
 
@@ -10739,7 +10753,7 @@ class JABS_EnemyAI
    * Handles how a follower decides its next action while engaged.
    * If a leader is ready, waits for their directive. Otherwise basic attacks.
    * @param {JABS_Battler} battler The follower battler deciding an action.
-   * @returns {number|null}
+   * @returns {number[]}
    */
   decideFollowerAi(battler)
   {
@@ -10767,7 +10781,7 @@ class JABS_EnemyAI
   /**
    * Allows the leader to decide this follower's next action.
    * @param {JABS_Battler} battler The follower deferring to a leader.
-   * @returns {number|null}
+   * @returns {number[]}
    */
   decideFollowerAiByLeader(battler)
   {
@@ -10775,24 +10789,24 @@ class JABS_EnemyAI
 
     const leaderDecidedSkillId = battler.getNextLeaderDecidedAction();
 
-    if (!this.isSkillIdValid(leaderDecidedSkillId)) return null;
+    if (!this.isSkillIdValid(leaderDecidedSkillId)) return [];
 
-    return leaderDecidedSkillId;
+    return [ leaderDecidedSkillId ];
   }
 
   /**
    * Allows the follower to decide their own next action.
    * Followers with no leader always basic attack.
    * @param {JABS_Battler} battler The follower deciding for themselves.
-   * @returns {number|null}
+   * @returns {number[]}
    */
   decideFollowerAiBySelf(battler)
   {
     const basicAttackSkillId = battler.getEnemyBasicAttack();
 
-    if (!this.isSkillIdValid(basicAttackSkillId)) return null;
+    if (!this.isSkillIdValid(basicAttackSkillId)) return [];
 
-    return basicAttackSkillId;
+    return [ basicAttackSkillId ];
   }
   //endregion follower
 
@@ -14029,7 +14043,7 @@ class JABS_Timer
 /*:
  * @target MZ
  * @plugindesc
- * [v4.7.1 JABS] Enables combat to be carried out on the map.
+ * [v4.7.2 JABS] Enables combat to be carried out on the map.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -14074,6 +14088,12 @@ class JABS_Timer
  * for JABS lives at the top instead of the bottom.
  *
  * CHANGELOG:
+ * - 4.7.2
+ *    Unified enemy and ally AI skill decisions to return a skill-id array (empty or one id);
+ *    JABS_AiManager phase-2 paths read the first element after validation.
+ *    JABS_AI#decideAction stub now returns an empty array to match concrete AI classes.
+ *    Fixed filterSkillsHealerPriority returning a scalar on the final healing-priority path
+ *    instead of an array.
  * - 4.7.1
  *    Added plugin parameter "Parry Map Animation Id" for the database
  *    animation played on successful parry (default 122; 0 disables).
@@ -16280,7 +16300,7 @@ J.ABS.Helpers.PluginManager.TranslateElementalIcons = obj =>
  */
 J.ABS.Metadata = {};
 J.ABS.Metadata.Name = 'J-ABS';
-J.ABS.Metadata.Version = '4.7.1';
+J.ABS.Metadata.Version = '4.7.2';
 
 /**
  * The actual `plugin parameters` extracted from RMMZ.
@@ -21203,13 +21223,14 @@ class JABS_AiManager
     // followers defer to their leader; if no leader is ready they basic attack.
     if (role.follower && !role.leader && !role.solo)
     {
-      const followerSkillId = battler.getAiMode().decideFollowerAi(battler);
-      if (!this.isSkillIdValid(followerSkillId))
+      const followerPicks = battler.getAiMode().decideFollowerAi(battler);
+      if (followerPicks.length === 0 || !this.isSkillIdValid(followerPicks[0]))
       {
         this.cancelActionSetup(battler);
         return;
       }
 
+      const followerSkillId = followerPicks[0];
       const followerSkill = battler.getSkill(followerSkillId);
       if (!followerSkill)
       {
@@ -21223,12 +21244,12 @@ class JABS_AiManager
     }
 
     // use the battler's AI to decide the skill.
-    const decidedSkillId = battler
+    const decidedPicks = battler
       .getAiMode()
       .decideAction(battler, battler.getTarget(), battler.getSkillIdsFromEnemy());
 
     // validate the skill chosen.
-    if (!this.isSkillIdValid(decidedSkillId))
+    if (decidedPicks.length === 0 || !this.isSkillIdValid(decidedPicks[0]))
     {
       // cancel the setup.
       this.cancelActionSetup(battler);
@@ -21236,6 +21257,8 @@ class JABS_AiManager
       // stop processing.
       return;
     }
+
+    const decidedSkillId = decidedPicks[0];
 
     // construct the skill from the battler's perspective.
     const skill = battler.getSkill(decidedSkillId);

--- a/chef-adventure/js/plugins/j/abs/ext/J-ABS-AllyAI.js
+++ b/chef-adventure/js/plugins/j/abs/ext/J-ABS-AllyAI.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v2.1.1 ALLYAI] Grants your allies AI to fight alongside the player.
+ * [v2.1.2 ALLYAI] Grants your allies AI to fight alongside the player.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -116,6 +116,9 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 2.1.2
+ *    decideAction and ally AI mode helpers now return a skill-id array, matching J-ABS 4.7.2.
+ *    Raised minimum J-ABS version to 4.7.2.
  * - 2.1.1
  *    Raised minimum J-ABS version to 4.7.0.
  * - 2.1.0
@@ -292,7 +295,7 @@ var J = J || {};
   }
 
   // Check to ensure we have the minimum required version of the J-ABS plugin.
-  const requiredJabsVersion = '4.6.0';
+  const requiredJabsVersion = '4.7.2';
   const hasJabsRequirement = J.BASE.Helpers.satisfies(J.ABS.Metadata.Version, requiredJabsVersion);
   if (!hasJabsRequirement)
   {
@@ -312,7 +315,7 @@ J.ABS.EXT.ALLYAI = {};
  */
 J.ABS.EXT.ALLYAI.Metadata = {};
 J.ABS.EXT.ALLYAI.Metadata.Name = `J-ABS-AllyAI`;
-J.ABS.EXT.ALLYAI.Metadata.Version = '2.1.0';
+J.ABS.EXT.ALLYAI.Metadata.Version = '2.1.2';
 
 /**
  * The actual `plugin parameters` extracted from RMMZ.
@@ -596,11 +599,22 @@ JABS_AllyAI.prototype.changeMode = function(newMode)
 
 //region decide action
 /**
+ * Wraps a base support helper result (0 means none) as a uniform skill-id list.
+ * @param {number} skillId
+ * @returns {number[]}
+ */
+JABS_AllyAI.prototype.wrapSupportSkillId = function(skillId)
+{
+  if (!skillId) return [];
+  return [ skillId ];
+};
+
+/**
  * Decides an action based on this battler's AI, the target, and the given available skills.
  * @param {JABS_Battler} user The battler of the AI deciding a skill.
  * @param {JABS_Battler} target The target battler to decide an action against.
  * @param {number[]} availableSkills A collection of all skill ids to potentially pick from.
- * @returns {number|null} The skill id chosen to use, or null if none were valid choices for this AI.
+ * @returns {number[]} Exactly one skill id, or empty when no valid choice exists.
  */
 JABS_AllyAI.prototype.decideAction = function(user, target, availableSkills)
 {
@@ -624,22 +638,24 @@ JABS_AllyAI.prototype.decideAction = function(user, target, availableSkills)
     case JABS_AllyAI.modes.SUPPORT.key:
       return this.decideSupport(usableSkills, user);
     default:
-      return usableSkills.at(0);
+    {
+      const fallbackId = usableSkills.at(0);
+      return this.isSkillIdValid(fallbackId) ? [ fallbackId ] : [];
+    }
   }
 };
 
 //region do-nothing
 /**
  * Decides to do nothing and waits a short amount of time before doing anything else.
- * @returns {null}
+ * @returns {number[]}
  */
 JABS_AllyAI.prototype.decideDoNothing = function(attacker)
 {
   // forces a short wait before thinking about what to do next.
   attacker.setWaitCountdown(20);
 
-  // return nothing to indicate no action should be taken.
-  return null;
+  return [];
 };
 //endregion do-nothing
 
@@ -648,15 +664,14 @@ JABS_AllyAI.prototype.decideDoNothing = function(attacker)
  * Decides a skill id based on the ai mode of "basic attack only".
  * @param {number[]} usableSkills The skill ids available to choose from.
  * @param {JABS_Battler} user The battler choosing the skill.
- * @returns {number|null}
+ * @returns {number[]}
  */
 JABS_AllyAI.prototype.decideBasicAttack = function(usableSkills, user)
 {
   // check first if we should follow with the next hit of the combo.
   if (this.shouldFollowWithCombo(user))
   {
-    // we're doing the next combo in the chain!
-    return this.followWithCombo(user);
+    return [ this.followWithCombo(user) ];
   }
 
   // determine which skill of the skills available is the mainhand skill.
@@ -670,29 +685,24 @@ JABS_AllyAI.prototype.decideBasicAttack = function(usableSkills, user)
       .findSlotForSkillId(id).key === JABS_Button.Offhand);
 
   // if we have neither basic attack skills, then do not process.
-  if (!mainBasicAttackSkillId && !offhandBasicAttackSkillId) return null;
+  if (!mainBasicAttackSkillId && !offhandBasicAttackSkillId) return [];
 
   // check if we have to decide between using mainhand or offhand.
   if (mainBasicAttackSkillId && offhandBasicAttackSkillId)
   {
-    // a 70% chance to use mainhand, 30% chance to use offhand by default.
-    return RPGManager.chanceIn100(70)
+    const picked = RPGManager.chanceIn100(70)
       ? mainBasicAttackSkillId
       : offhandBasicAttackSkillId;
+    return [ picked ];
   }
 
   // check if we do not have a mainhand skill.
   if (!mainBasicAttackSkillId)
   {
-    // in which case we return the offhand skill.
-    return offhandBasicAttackSkillId;
+    return [ offhandBasicAttackSkillId ];
   }
-  // since we do have a mainhand skill.
-  else
-  {
-    // lets return it.
-    return mainBasicAttackSkillId;
-  }
+
+  return [ mainBasicAttackSkillId ];
 };
 //endregion basic-attack
 
@@ -705,15 +715,14 @@ JABS_AllyAI.prototype.decideBasicAttack = function(usableSkills, user)
  * @param {number[]} usableSkills The skill ids available to choose from.
  * @param {JABS_Battler} user The battler choosing the skill.
  * @param {JABS_Battler} target The targeted battler to use the skill against.
- * @returns {number}
+ * @returns {number[]}
  */
 JABS_AllyAI.prototype.decideVariety = function(usableSkills, user, target)
 {
   // check first if we should follow with the next hit of the combo.
   if (this.shouldFollowWithCombo(user))
   {
-    // we're doing the next combo in the chain!
-    return this.followWithCombo(user);
+    return [ this.followWithCombo(user) ];
   }
 
   // initialize the chosen skill id.
@@ -762,8 +771,8 @@ JABS_AllyAI.prototype.decideVariety = function(usableSkills, user, target)
     chosenSkillId = tempAvailableSkills[Math.randomInt(tempAvailableSkills.length)];
   }
 
-  // return the decided skill id.
-  return chosenSkillId;
+  if (!this.isSkillIdValid(chosenSkillId)) return [];
+  return [ chosenSkillId ];
 };
 //endregion variety
 
@@ -775,15 +784,14 @@ JABS_AllyAI.prototype.decideVariety = function(usableSkills, user, target)
  * @param {number[]} usableSkills The skill ids available to choose from.
  * @param {JABS_Battler} user The battler choosing the skill.
  * @param {JABS_Battler} target The targeted battler to use the skill against.
- * @returns {number}
+ * @returns {number[]}
  */
 JABS_AllyAI.prototype.decideFullForce = function(usableSkills, user, target)
 {
   // check first if we should follow with the next hit of the combo.
   if (this.shouldFollowWithCombo(user))
   {
-    // we're doing the next combo in the chain!
-    return this.followWithCombo(user);
+    return [ this.followWithCombo(user) ];
   }
 
   let chosenSkillId = 0;
@@ -836,8 +844,8 @@ JABS_AllyAI.prototype.decideFullForce = function(usableSkills, user, target)
     chosenSkillId = tempAvailableSkills.at(Math.randomInt(tempAvailableSkills.length));
   }
 
-  // return the chosen skill.
-  return chosenSkillId;
+  if (!this.isSkillIdValid(chosenSkillId)) return [];
+  return [ chosenSkillId ];
 };
 //endregion full-force
 
@@ -848,28 +856,27 @@ JABS_AllyAI.prototype.decideFullForce = function(usableSkills, user, target)
  * Support priorities = cleansing > healing > buffing.
  * @param {number[]} usableSkills The skill ids available to choose from.
  * @param {JABS_Battler} user The battler choosing the skill.
- * @returns {number} The chosen support skill id to perform.
+ * @returns {number[]}
  */
 JABS_AllyAI.prototype.decideSupport = function(usableSkills, user)
 {
   // check first if we should follow with the next hit of the combo.
   if (this.shouldFollowWithCombo(user))
   {
-    // we're doing the next combo in the chain!
-    return this.followWithCombo(user);
+    return [ this.followWithCombo(user) ];
   }
 
   // first priority is cleansing status ailments, including death, from allies.
-  const cleanseId = this.decideCleansing(user, usableSkills);
-  if (cleanseId) return cleanseId;
+  const cleansePick = this.wrapSupportSkillId(this.decideCleansing(user, usableSkills));
+  if (cleansePick.length) return cleansePick;
 
   // second priority is recovering missing health for allies.
-  const healId = this.decideHealing(user, usableSkills);
-  if (healId) return healId;
+  const healPick = this.wrapSupportSkillId(this.decideHealing(user, usableSkills));
+  if (healPick.length) return healPick;
 
   // third priority is status buffing on allies.
-  const buffId = this.decideBuffing(user, usableSkills);
-  if (buffId) return buffId;
+  const buffPick = this.wrapSupportSkillId(this.decideBuffing(user, usableSkills));
+  if (buffPick.length) return buffPick;
 
   // nothing needed; wait briefly.
   return this.decideDoNothing(user);
@@ -1538,12 +1545,12 @@ JABS_AiManager.decideAllyAiPhase2Action = function(jabsBattler)
   const currentlyEquippedSkillIds = validSkillSlots.map(skillSlot => skillSlot.id);
 
   // decide the action based on the ally ai mode currently assigned.
-  const decidedSkillId = jabsBattler
+  const decidedPicks = jabsBattler
     .getAllyAiMode()
     .decideAction(jabsBattler, jabsBattler.getTarget(), currentlyEquippedSkillIds);
 
   // validate the skill chosen.
-  if (!this.isSkillIdValid(decidedSkillId))
+  if (decidedPicks.length === 0 || !this.isSkillIdValid(decidedPicks[0]))
   {
     // cancel the setup.
     this.cancelActionSetup(jabsBattler);
@@ -1551,6 +1558,8 @@ JABS_AiManager.decideAllyAiPhase2Action = function(jabsBattler)
     // stop processing.
     return;
   }
+
+  const decidedSkillId = decidedPicks[0];
 
   // TODO: allow allies to use dodge skills, but code the AI to use it intelligently.
   // check if the skill id is actually a mobility skill.


### PR DESCRIPTION
Sync Chef Adventure plugin drop with rmmz-plugins hotfix: **J-ABS 4.7.2** and **J-ABS-AllyAI 2.1.2** (unified AI decision arrays), plus other built plugins from the same mirror pass.

Install **J-ABS 4.7.2** before **J-ABS-AllyAI 2.1.2** (AllyAI now requires J-ABS 4.7.2+).
