### PR TITLE
Mirror the JSDoc and signature pass (rmmz-plugins#69)

### DIFF
--- a/chef-adventure/js/plugins/j/abs/J-ABS.js
+++ b/chef-adventure/js/plugins/j/abs/J-ABS.js
@@ -6201,7 +6201,7 @@ var JABS_HitboxPulseOptions = class JABS_HitboxPulseOptions {
 var Sprite_HitboxPulse = class extends Sprite {
 	/**
 	* Gets the sustained.
-	* @returns {*} The sustained.
+	* @returns {boolean} The sustained.
 	*/
 	isSustained() {
 		return this._sustained;
@@ -6299,14 +6299,14 @@ var Sprite_HitboxPulse = class extends Sprite {
 	}
 	/**
 	* Gets the line color.
-	* @returns {*} The lineColor.
+	* @returns {number} The lineColor.
 	*/
 	lineColor() {
 		return this._lineColor;
 	}
 	/**
 	* Sets the line color.
-	* @param {*} newLineColor The new lineColor.
+	* @param {number} newLineColor The new lineColor.
 	*/
 	setLineColor(newLineColor) {
 		this._lineColor = newLineColor;
@@ -6341,14 +6341,14 @@ var Sprite_HitboxPulse = class extends Sprite {
 	}
 	/**
 	* Gets the fill color.
-	* @returns {*} The fillColor.
+	* @returns {number} The fillColor.
 	*/
 	fillColor() {
 		return this._fillColor;
 	}
 	/**
 	* Sets the fill color.
-	* @param {*} newFillColor The new fillColor.
+	* @param {number} newFillColor The new fillColor.
 	*/
 	setFillColor(newFillColor) {
 		this._fillColor = newFillColor;
@@ -6369,14 +6369,14 @@ var Sprite_HitboxPulse = class extends Sprite {
 	}
 	/**
 	* Gets the shape.
-	* @returns {*} The shape.
+	* @returns {string} The shape.
 	*/
 	shape() {
 		return this._shape;
 	}
 	/**
 	* Sets the shape.
-	* @param {*} newShape The new shape.
+	* @param {string} newShape The new shape.
 	*/
 	setShape(newShape) {
 		this._shape = newShape;
@@ -7462,10 +7462,15 @@ var JABS_ActionSpawner = class {
 var JABS_BattlerRole = class {
 	/**
 	* Constructor.
-	* @param {...*} args Forwarded to {@link #initialize}.
+	* @param {boolean=} leader Whether this battler coordinates nearby followers.
+	* @param {boolean=} follower Whether this battler defers to a nearby leader.
+	* @param {boolean=} guardian Whether this battler protects a nearby ward.
+	* @param {boolean=} ward Whether this battler should be protected by nearby guardians.
+	* @param {boolean=} solo Whether this battler explicitly opts out of all coordination.
+	* @param {boolean=} sentinel Whether this battler holds position rather than pursuing.
 	*/
-	constructor(...args) {
-		this.initialize(...args);
+	constructor(leader = false, follower = false, guardian = false, ward = false, solo = false, sentinel = false) {
+		this.initialize(leader, follower, guardian, ward, solo, sentinel);
 	}
 	/**
 	* Initializes this role object.
@@ -8827,10 +8832,10 @@ var JABS_BattlerCoreDataBuilder = class {
 var JABS_BattlerCoreData = class {
 	/**
 	* Constructor.
-	* @param {...*} args Forwarded to {@link #initialize}.
+	* @param {object} coreData The bundle of core properties; see {@link #initialize} for its shape.
 	*/
-	constructor(...args) {
-		this.initialize(...args);
+	constructor(coreData) {
+		this.initialize(coreData);
 	}
 	/**
 	* Initializes this battler data object.
@@ -11525,7 +11530,7 @@ SerializableRegistry.register(JABS_SkillSlot, { typed: { cooldown: JABS_Cooldown
 var JABS_Battler = class JABS_Battler {
 	/**
 	* Gets the prepare ready.
-	* @returns {*} The prepareReady.
+	* @returns {boolean} The prepareReady.
 	*/
 	/**
 	* Sets the hidden.
@@ -11867,7 +11872,7 @@ var JABS_Battler = class JABS_Battler {
 	}
 	/**
 	* Gets the wait timer.
-	* @returns {*} The waitTimer.
+	* @returns {JABS_Timer} The waitTimer.
 	*/
 	waitTimer() {
 		return this._waitTimer;
@@ -17312,7 +17317,7 @@ var JABS_LootDrop = class {
 	}
 	/**
 	* Sets the duration.
-	* @param {*} newDuration The new duration.
+	* @param {number} newDuration The new duration.
 	*/
 	/**
 	* The duration that this loot drop will exist on the map.
@@ -21569,7 +21574,7 @@ var JABS_Action = class JABS_Action {
 	}
 	/**
 	* Gets the hits per connection bonus.
-	* @returns {*} The hitsPerConnectionBonus.
+	* @returns {number} The hitsPerConnectionBonus.
 	*/
 	hitsPerConnectionBonus() {
 		return this._hitsPerConnectionBonus;
@@ -21611,14 +21616,14 @@ var JABS_Action = class JABS_Action {
 	}
 	/**
 	* Gets the action map visual note holder.
-	* @returns {*} The actionMapVisualNoteHolder.
+	* @returns {{ note: string }|null} The actionMapVisualNoteHolder.
 	*/
 	actionMapVisualNoteHolder() {
 		return this._actionMapVisualNoteHolder;
 	}
 	/**
 	* Sets the action map visual note holder.
-	* @param {*} newActionMapVisualNoteHolder The new actionMapVisualNoteHolder.
+	* @param {{ note: string }|null} newActionMapVisualNoteHolder The new actionMapVisualNoteHolder.
 	*/
 	setActionMapVisualNoteHolder(newActionMapVisualNoteHolder) {
 		this._actionMapVisualNoteHolder = newActionMapVisualNoteHolder;
@@ -21653,7 +21658,7 @@ var JABS_Action = class JABS_Action {
 	}
 	/**
 	* Gets the delay.
-	* @returns {*} The delay.
+	* @returns {{_delayDuration: JABS_Timer, _triggerOnTouch: boolean, _triggerRadius: number|null}} The delay.
 	*/
 	delay() {
 		return this._delay;
@@ -22982,7 +22987,7 @@ var JABS_SkillSlotManager = class {
 	}
 	/**
 	* Gets the slots.
-	* @returns {*} The slots.
+	* @returns {JABS_SkillSlot[]} The slots.
 	*/
 	slots() {
 		return this._slots;
@@ -27877,14 +27882,14 @@ Game_Actor.prototype.turnEndOnMap = function() {
 };
 /**
 * Gets the death effect.
-* @returns {*} The deathEffect.
+* @returns {boolean} The deathEffect.
 */
 Game_Actor.prototype.deathEffect = function() {
 	return this._j._abs._deathEffect;
 };
 /**
 * Sets the death effect.
-* @param {*} newDeathEffect The new deathEffect.
+* @param {boolean} newDeathEffect The new deathEffect.
 */
 Game_Actor.prototype.setDeathEffect = function(newDeathEffect) {
 	this._j._abs._deathEffect = newDeathEffect;
@@ -29322,14 +29327,14 @@ Game_Battler.prototype.getResolvedSkillId = function(slot) {
 Game_Battler.prototype.regenerateAll = function() {};
 /**
 * Gets the last damage source.
-* @returns {*} The lastDamageSource.
+* @returns {{type: string, uuid: string, id: number}|null} The lastDamageSource.
 */
 Game_Battler.prototype.lastDamageSource = function() {
 	return this._j._abs._lastDamageSource;
 };
 /**
 * Sets the last damage source.
-* @param {*} newLastDamageSource The new lastDamageSource.
+* @param {{type: string, uuid: string, id: number}|null} newLastDamageSource The new lastDamageSource.
 */
 Game_Battler.prototype.setLastDamageSource = function(newLastDamageSource) {
 	this._j._abs._lastDamageSource = newLastDamageSource;
@@ -29343,7 +29348,7 @@ Game_Battler.prototype.uuid = function() {
 };
 /**
 * Gets the encore repeats.
-* @returns {*} The encoreRepeats.
+* @returns {number} The encoreRepeats.
 */
 Game_Battler.prototype.encoreRepeats = function() {
 	return this._j._abs._encoreRepeats;
@@ -30056,14 +30061,14 @@ Game_CharacterBase.prototype.glideTo = function(xPlus, yPlus) {
 };
 /**
 * Gets the no jump arc.
-* @returns {*} The noJumpArc.
+* @returns {boolean} The noJumpArc.
 */
 Game_CharacterBase.prototype.isNoJumpArc = function() {
 	return this._j._abs._noJumpArc;
 };
 /**
 * Sets the no jump arc.
-* @param {*} newNoJumpArc The new noJumpArc.
+* @param {boolean} newNoJumpArc The new noJumpArc.
 */
 Game_CharacterBase.prototype.setNoJumpArc = function(newNoJumpArc) {
 	this._j._abs._noJumpArc = newNoJumpArc;
@@ -32017,46 +32022,49 @@ var Sprite_MapCastGauge = class extends Sprite_MapGauge {
 	}
 	/**
 	* Gets the expected character.
-	* @returns {*} The expectedCharacter.
+	* @returns {Game_Character|null} The expectedCharacter.
 	*/
 	expectedCharacter() {
 		return this._expectedCharacter;
 	}
 	/**
 	* Sets the expected character.
-	* @param {*} newExpectedCharacter The new expectedCharacter.
+	* @param {Game_Character|null} newExpectedCharacter The new expectedCharacter.
 	*/
 	setExpectedCharacter(newExpectedCharacter) {
 		this._expectedCharacter = newExpectedCharacter;
 	}
 	/**
 	* Gets the expected uuid.
-	* @returns {*} The expectedUuid.
+	* @returns {string|null} The expectedUuid.
 	*/
 	expectedUuid() {
 		return this._expectedUuid;
 	}
 	/**
 	* Sets the expected uuid.
-	* @param {*} newExpectedUuid The new expectedUuid.
+	* @param {string|null} newExpectedUuid The new expectedUuid.
 	*/
 	setExpectedUuid(newExpectedUuid) {
 		this._expectedUuid = newExpectedUuid;
 	}
 	/**
 	* Gets the gauge.
-	* @returns {*} The gauge.
+	* @returns {{_bitmapWidth: number, _bitmapHeight: number, _gaugeHeight: number, _label: string,
+	* _value: number|null, _iconIndex: number, _iconSprite: Sprite|null, _activated: boolean}} The gauge.
 	*/
 	gauge() {
 		return this._gauge;
 	}
 	/**
 	* Constructor.
-	* @param {...*} args Forwarded to {@link #initialize}.
+	* @param {number=} bitmapWidth The bitmap width of this gauge.
+	* @param {number=} bitmapHeight The bitmap height of this gauge.
+	* @param {number=} gaugeHeight The height of the filled strip.
 	*/
-	constructor(...args) {
+	constructor(bitmapWidth = 128, bitmapHeight = 24, gaugeHeight = 10) {
 		super();
-		this.initialize(...args);
+		this.initialize(bitmapWidth, bitmapHeight, gaugeHeight);
 	}
 	/**
 	* Initializes this map cast gauge with the given parameters.
@@ -32601,6 +32609,7 @@ Sprite_Character.prototype.initGaugeMembers = function() {
 	this._j._abs._gauges._hpGauge = null;
 	/**
 	* The cast gauge for this sprite.
+	* @type {Sprite_MapCastGauge|null}
 	*/
 	this._j._abs._gauges._castGauge = null;
 	/**
@@ -33569,28 +33578,28 @@ Sprite_Character.prototype.shouldSwingDown = function() {
 };
 /**
 * Gets the jabs battler setup complete.
-* @returns {*} The jabsBattlerSetupComplete.
+* @returns {boolean} The jabsBattlerSetupComplete.
 */
 Sprite_Character.prototype.isJabsBattlerSetupComplete = function() {
 	return this._j._abs._jabsBattlerSetupComplete;
 };
 /**
 * Sets the jabs battler setup complete.
-* @param {*} newJabsBattlerSetupComplete The new jabsBattlerSetupComplete.
+* @param {boolean} newJabsBattlerSetupComplete The new jabsBattlerSetupComplete.
 */
 Sprite_Character.prototype.setJabsBattlerSetupComplete = function(newJabsBattlerSetupComplete) {
 	this._j._abs._jabsBattlerSetupComplete = newJabsBattlerSetupComplete;
 };
 /**
 * Gets the loot setup complete.
-* @returns {*} The lootSetupComplete.
+* @returns {boolean} The lootSetupComplete.
 */
 Sprite_Character.prototype.isLootSetupComplete = function() {
 	return this._j._abs._loot._lootSetupComplete;
 };
 /**
 * Sets the loot setup complete.
-* @param {*} newLootSetupComplete The new lootSetupComplete.
+* @param {boolean} newLootSetupComplete The new lootSetupComplete.
 */
 Sprite_Character.prototype.setLootSetupComplete = function(newLootSetupComplete) {
 	this._j._abs._loot._lootSetupComplete = newLootSetupComplete;
@@ -33611,28 +33620,28 @@ Sprite_Character.prototype.setStateOverlaySprite = function(newStateOverlaySprit
 };
 /**
 * Gets the cast gauge.
-* @returns {*} The castGauge.
+* @returns {Sprite_MapCastGauge|null} The castGauge.
 */
 Sprite_Character.prototype.castGauge = function() {
 	return this._j._abs._gauges._castGauge;
 };
 /**
 * Sets the cast gauge.
-* @param {*} newCastGauge The new castGauge.
+* @param {Sprite_MapCastGauge|null} newCastGauge The new castGauge.
 */
 Sprite_Character.prototype.setCastGauge = function(newCastGauge) {
 	this._j._abs._gauges._castGauge = newCastGauge;
 };
 /**
 * Gets the affliction strip.
-* @returns {*} The afflictionStrip.
+* @returns {Sprite_MapAfflictionStrip|null} The afflictionStrip.
 */
 Sprite_Character.prototype.afflictionStrip = function() {
 	return this._j._abs._gauges._afflictionStrip;
 };
 /**
 * Sets the affliction strip.
-* @param {*} newAfflictionStrip The new afflictionStrip.
+* @param {Sprite_MapAfflictionStrip|null} newAfflictionStrip The new afflictionStrip.
 */
 Sprite_Character.prototype.setAfflictionStrip = function(newAfflictionStrip) {
 	this._j._abs._gauges._afflictionStrip = newAfflictionStrip;
@@ -34954,84 +34963,84 @@ Spriteset_Map.prototype.destroyBattlerHitboxSprite = function(sprite) {
 };
 /**
 * Gets the debug hitbox layer.
-* @returns {*} The debugHitboxLayer.
+* @returns {Sprite} The debugHitboxLayer.
 */
 Spriteset_Map.prototype.debugHitboxLayer = function() {
 	return this._j._abs._debugHitboxLayer;
 };
 /**
 * Sets the debug hitbox layer.
-* @param {*} newDebugHitboxLayer The new debugHitboxLayer.
+* @param {Sprite} newDebugHitboxLayer The new debugHitboxLayer.
 */
 Spriteset_Map.prototype.setDebugHitboxLayer = function(newDebugHitboxLayer) {
 	this._j._abs._debugHitboxLayer = newDebugHitboxLayer;
 };
 /**
 * Gets the debug action hitbox sprites.
-* @returns {*} The debugActionHitboxSprites.
+* @returns {Record<string, Sprite>} The debugActionHitboxSprites.
 */
 Spriteset_Map.prototype.debugActionHitboxSprites = function() {
 	return this._j._abs._debugActionHitboxSprites;
 };
 /**
 * Sets the debug action hitbox sprites.
-* @param {*} newDebugActionHitboxSprites The new debugActionHitboxSprites.
+* @param {Record<string, Sprite>} newDebugActionHitboxSprites The new debugActionHitboxSprites.
 */
 Spriteset_Map.prototype.setDebugActionHitboxSprites = function(newDebugActionHitboxSprites) {
 	this._j._abs._debugActionHitboxSprites = newDebugActionHitboxSprites;
 };
 /**
 * Gets the debug battler hitbox sprites.
-* @returns {*} The debugBattlerHitboxSprites.
+* @returns {Record<string, Sprite>} The debugBattlerHitboxSprites.
 */
 Spriteset_Map.prototype.debugBattlerHitboxSprites = function() {
 	return this._j._abs._debugBattlerHitboxSprites;
 };
 /**
 * Sets the debug battler hitbox sprites.
-* @param {*} newDebugBattlerHitboxSprites The new debugBattlerHitboxSprites.
+* @param {Record<string, Sprite>} newDebugBattlerHitboxSprites The new debugBattlerHitboxSprites.
 */
 Spriteset_Map.prototype.setDebugBattlerHitboxSprites = function(newDebugBattlerHitboxSprites) {
 	this._j._abs._debugBattlerHitboxSprites = newDebugBattlerHitboxSprites;
 };
 /**
 * Gets the cast preview sprites.
-* @returns {*} The castPreviewSprites.
+* @returns {Record<string, Sprite>} The castPreviewSprites.
 */
 Spriteset_Map.prototype.castPreviewSprites = function() {
 	return this._j._abs._castPreviewSprites;
 };
 /**
 * Sets the cast preview sprites.
-* @param {*} newCastPreviewSprites The new castPreviewSprites.
+* @param {Record<string, Sprite>} newCastPreviewSprites The new castPreviewSprites.
 */
 Spriteset_Map.prototype.setCastPreviewSprites = function(newCastPreviewSprites) {
 	this._j._abs._castPreviewSprites = newCastPreviewSprites;
 };
 /**
 * Gets the cast preview layer.
-* @returns {*} The castPreviewLayer.
+* @returns {Sprite} The castPreviewLayer.
 */
 Spriteset_Map.prototype.castPreviewLayer = function() {
 	return this._j._abs._castPreviewLayer;
 };
 /**
 * Sets the cast preview layer.
-* @param {*} newCastPreviewLayer The new castPreviewLayer.
+* @param {Sprite} newCastPreviewLayer The new castPreviewLayer.
 */
 Spriteset_Map.prototype.setCastPreviewLayer = function(newCastPreviewLayer) {
 	this._j._abs._castPreviewLayer = newCastPreviewLayer;
 };
 /**
 * Gets the hitbox pulse layer.
-* @returns {*} The hitboxPulseLayer.
+* @returns {Sprite} The hitboxPulseLayer.
 */
 Spriteset_Map.prototype.hitboxPulseLayer = function() {
 	return this._j._abs._hitboxPulseLayer;
 };
 /**
 * Sets the hitbox pulse layer.
-* @param {*} newHitboxPulseLayer The new hitboxPulseLayer.
+* @param {Sprite} newHitboxPulseLayer The new hitboxPulseLayer.
 */
 Spriteset_Map.prototype.setHitboxPulseLayer = function(newHitboxPulseLayer) {
 	this._j._abs._hitboxPulseLayer = newHitboxPulseLayer;

--- a/chef-adventure/js/plugins/j/abs/ext/J-ABS-AllyAI.js
+++ b/chef-adventure/js/plugins/j/abs/ext/J-ABS-AllyAI.js
@@ -572,11 +572,11 @@ var JABS_AllyAI = class JABS_AllyAI extends JABS_AI {
 	}
 	/**
 	* Constructor.
-	* @param {...*} args Forwarded to {@link #initialize}.
+	* @param {string=} presetKey The preset key to apply on construction.
 	*/
-	constructor(...args) {
+	constructor(presetKey) {
 		super();
-		this.initialize(...args);
+		this.initialize(presetKey);
 	}
 	/**
 	* Initializes this ally AI with an optional starting preset.

--- a/chef-adventure/js/plugins/j/abs/ext/J-ABS-Charge.js
+++ b/chef-adventure/js/plugins/j/abs/ext/J-ABS-Charge.js
@@ -1306,7 +1306,7 @@ JABS_StandardController.prototype.canChargeCombatAction4 = function() {
 };
 /**
 * Gets the charge input delay.
-* @returns {*} The chargeInputDelay.
+* @returns {Map<string, JABS_Timer>} The chargeInputDelay.
 */
 JABS_StandardController.prototype.chargeInputDelay = function() {
 	return this._chargeInputDelay;
@@ -1408,46 +1408,49 @@ var Sprite_MapChargeGauge = class extends Sprite_MapGauge {
 	}
 	/**
 	* Gets the expected character.
-	* @returns {*} The expectedCharacter.
+	* @returns {Game_Character|null} The expectedCharacter.
 	*/
 	expectedCharacter() {
 		return this._expectedCharacter;
 	}
 	/**
 	* Sets the expected character.
-	* @param {*} newExpectedCharacter The new expectedCharacter.
+	* @param {Game_Character|null} newExpectedCharacter The new expectedCharacter.
 	*/
 	setExpectedCharacter(newExpectedCharacter) {
 		this._expectedCharacter = newExpectedCharacter;
 	}
 	/**
 	* Gets the expected uuid.
-	* @returns {*} The expectedUuid.
+	* @returns {string|null} The expectedUuid.
 	*/
 	expectedUuid() {
 		return this._expectedUuid;
 	}
 	/**
 	* Sets the expected uuid.
-	* @param {*} newExpectedUuid The new expectedUuid.
+	* @param {string|null} newExpectedUuid The new expectedUuid.
 	*/
 	setExpectedUuid(newExpectedUuid) {
 		this._expectedUuid = newExpectedUuid;
 	}
 	/**
 	* Gets the gauge.
-	* @returns {*} The gauge.
+	* @returns {{_bitmapWidth: number, _bitmapHeight: number, _gaugeHeight: number, _label: string,
+	* _value: number|null, _iconIndex: number, _iconSprite: Sprite|null, _activated: boolean}} The gauge.
 	*/
 	gauge() {
 		return this._gauge;
 	}
 	/**
 	* Constructor.
-	* @param {...*} args Forwarded to {@link #initialize}.
+	* @param {number=} bitmapWidth The bitmap width of this gauge.
+	* @param {number=} bitmapHeight The bitmap height of this gauge.
+	* @param {number=} gaugeHeight The height of the filled strip.
 	*/
-	constructor(...args) {
+	constructor(bitmapWidth = 128, bitmapHeight = 24, gaugeHeight = 10) {
 		super();
-		this.initialize(...args);
+		this.initialize(bitmapWidth, bitmapHeight, gaugeHeight);
 	}
 	/**
 	* Initializes this charge gauge with the given parameters.
@@ -1753,14 +1756,14 @@ Sprite_Character.prototype.hideChargeGauge = function() {
 };
 /**
 * Gets the charge gauge.
-* @returns {*} The chargeGauge.
+* @returns {Sprite_MapChargeGauge|null} The chargeGauge.
 */
 Sprite_Character.prototype.chargeGauge = function() {
 	return this._j._abs._gauges._chargeGauge;
 };
 /**
 * Sets the charge gauge.
-* @param {*} newChargeGauge The new chargeGauge.
+* @param {Sprite_MapChargeGauge|null} newChargeGauge The new chargeGauge.
 */
 Sprite_Character.prototype.setChargeGauge = function(newChargeGauge) {
 	this._j._abs._gauges._chargeGauge = newChargeGauge;

--- a/chef-adventure/js/plugins/j/abs/ext/J-ABS-DangerIndicator.js
+++ b/chef-adventure/js/plugins/j/abs/ext/J-ABS-DangerIndicator.js
@@ -533,14 +533,14 @@ Sprite_Character.prototype.hideDangerIndicator = function() {
 };
 /**
 * Gets the danger indicator.
-* @returns {*} The dangerIndicator.
+* @returns {Sprite_Icon} The dangerIndicator.
 */
 Sprite_Character.prototype.dangerIndicator = function() {
 	return this._j._dangerIndicator;
 };
 /**
 * Sets the danger indicator.
-* @param {*} newDangerIndicator The new dangerIndicator.
+* @param {Sprite_Icon} newDangerIndicator The new dangerIndicator.
 */
 Sprite_Character.prototype.setDangerIndicator = function(newDangerIndicator) {
 	this._j._dangerIndicator = newDangerIndicator;

--- a/chef-adventure/js/plugins/j/abs/ext/J-ABS-Food.js
+++ b/chef-adventure/js/plugins/j/abs/ext/J-ABS-Food.js
@@ -703,7 +703,7 @@ JABS_Engine.prototype.setFoodChainPlanByUuid = function(uuid, plan) {
 };
 /**
 * Gets the food chain plans.
-* @returns {*} The foodChainPlans.
+* @returns {Map<string, JABS_FoodChainPlan>} The foodChainPlans.
 */
 JABS_Engine.prototype.foodChainPlans = function() {
 	return this._foodChainPlans;

--- a/chef-adventure/js/plugins/j/abs/ext/J-ABS-Formula.js
+++ b/chef-adventure/js/plugins/j/abs/ext/J-ABS-Formula.js
@@ -958,7 +958,7 @@ Game_Action.prototype.applyGlobal = function() {
 };
 /**
 * Gets the filter formula eligible battler.
-* @returns {*} The filterFormulaEligibleBattler.
+* @returns {Function} The filterFormulaEligibleBattler.
 */
 Game_Action.prototype.filterFormulaEligibleBattler = function() {
 	return this._filterFormulaEligibleBattler;

--- a/chef-adventure/js/plugins/j/abs/ext/J-ABS-InputManager.js
+++ b/chef-adventure/js/plugins/j/abs/ext/J-ABS-InputManager.js
@@ -2296,7 +2296,8 @@ var Window_JabsRemapPrompt = class Window_JabsRemapPrompt extends Window_Base {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_abs: {_input: {_remapCaptured: string|null, _remapActive: boolean,
+	* _remapWarmup: number, _remapTimeout: number, _remapButtonLabel: string}}}} The j.
 	*/
 	j() {
 		return this._j;
@@ -2642,7 +2643,8 @@ var Window_JabsRemapActions = class extends Window_Command {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_abs: {_input: {_actions: {_state: {_mapping: object, _externalMapping: object,
+	* _buttons: string[]}, _view: {_helpWindow: Window_Base|null}}}}}} The j.
 	*/
 	j() {
 		return this._j;

--- a/chef-adventure/js/plugins/j/abs/ext/J-ABS-Juice.js
+++ b/chef-adventure/js/plugins/j/abs/ext/J-ABS-Juice.js
@@ -619,7 +619,7 @@ var JuiceWeaponSwingMotionEffect = class JuiceWeaponSwingMotionEffect extends Ju
 	}
 	/**
 	* Gets the motion type.
-	* @returns {*} The motionType.
+	* @returns {string} The motionType.
 	*/
 	motionType() {
 		return this._motionType;
@@ -633,28 +633,28 @@ var JuiceWeaponSwingMotionEffect = class JuiceWeaponSwingMotionEffect extends Ju
 	}
 	/**
 	* Gets the trail.
-	* @returns {*} The trail.
+	* @returns {{sprite: Sprite, ttl: number}[]} The trail.
 	*/
 	trail() {
 		return this._trail;
 	}
 	/**
 	* Sets the trail.
-	* @param {*} newTrail The new trail.
+	* @param {{sprite: Sprite, ttl: number}[]} newTrail The new trail.
 	*/
 	setTrail(newTrail) {
 		this._trail = newTrail;
 	}
 	/**
 	* Gets the arc span degrees.
-	* @returns {*} The arcSpanDegrees.
+	* @returns {number} The arcSpanDegrees.
 	*/
 	arcSpanDegrees() {
 		return this._arcSpanDegrees;
 	}
 	/**
 	* Gets the base rotation.
-	* @returns {*} The baseRotation.
+	* @returns {number} The baseRotation.
 	*/
 	baseRotation() {
 		return this._baseRotation;
@@ -1565,14 +1565,14 @@ var JuiceProfileResolver = class JuiceProfileResolver {
 var JuiceTiltMotionEffect = class extends JuiceBaseEffect {
 	/**
 	* Gets the sprite.
-	* @returns {*} The sprite.
+	* @returns {Sprite} The sprite.
 	*/
 	sprite() {
 		return this._sprite;
 	}
 	/**
 	* Gets the base rotation.
-	* @returns {*} The baseRotation.
+	* @returns {number} The baseRotation.
 	*/
 	baseRotation() {
 		return this._baseRotation;
@@ -1600,7 +1600,7 @@ var JuiceTiltMotionEffect = class extends JuiceBaseEffect {
 	}
 	/**
 	* Gets the peak radians.
-	* @returns {*} The peakRadians.
+	* @returns {number} The peakRadians.
 	*/
 	peakRadians() {
 		return this._peakRadians;
@@ -1661,7 +1661,7 @@ var JuiceTiltMotionEffect = class extends JuiceBaseEffect {
 var JuiceSquishMotionEffect = class extends JuiceBaseEffect {
 	/**
 	* Gets the sprite.
-	* @returns {*} The sprite.
+	* @returns {Sprite} The sprite.
 	*/
 	sprite() {
 		return this._sprite;
@@ -1703,21 +1703,21 @@ var JuiceSquishMotionEffect = class extends JuiceBaseEffect {
 	}
 	/**
 	* Gets the intensity scale.
-	* @returns {*} The intensityScale.
+	* @returns {number} The intensityScale.
 	*/
 	intensityScale() {
 		return this._intensityScale;
 	}
 	/**
 	* Gets the repeats remaining.
-	* @returns {*} The repeatsRemaining.
+	* @returns {number} The repeatsRemaining.
 	*/
 	repeatsRemaining() {
 		return this._repeatsRemaining;
 	}
 	/**
 	* Sets the repeats remaining.
-	* @param {*} newRepeatsRemaining The new repeatsRemaining.
+	* @param {number} newRepeatsRemaining The new repeatsRemaining.
 	*/
 	setRepeatsRemaining(newRepeatsRemaining) {
 		this._repeatsRemaining = newRepeatsRemaining;
@@ -1791,7 +1791,7 @@ var JuiceSquishMotionEffect = class extends JuiceBaseEffect {
 var JuiceCastingPulseMotionEffect = class extends JuiceBaseEffect {
 	/**
 	* Gets the sprite.
-	* @returns {*} The sprite.
+	* @returns {Sprite} The sprite.
 	*/
 	sprite() {
 		return this._sprite;
@@ -1812,14 +1812,14 @@ var JuiceCastingPulseMotionEffect = class extends JuiceBaseEffect {
 	}
 	/**
 	* Gets the base blend color.
-	* @returns {*} The baseBlendColor.
+	* @returns {[number, number, number, number]} The baseBlendColor.
 	*/
 	baseBlendColor() {
 		return this._baseBlendColor;
 	}
 	/**
 	* Gets the base color tone.
-	* @returns {*} The baseColorTone.
+	* @returns {[number, number, number, number]} The baseColorTone.
 	*/
 	baseColorTone() {
 		return this._baseColorTone;
@@ -1840,7 +1840,7 @@ var JuiceCastingPulseMotionEffect = class extends JuiceBaseEffect {
 	}
 	/**
 	* Gets the amplitude scale.
-	* @returns {*} The amplitudeScale.
+	* @returns {number} The amplitudeScale.
 	*/
 	amplitudeScale() {
 		return this._amplitudeScale;
@@ -1929,14 +1929,14 @@ var JuiceCastingPulseMotionEffect = class extends JuiceBaseEffect {
 var JuiceFlipBodyMotionEffect = class extends JuiceBaseEffect {
 	/**
 	* Gets the sprite.
-	* @returns {*} The sprite.
+	* @returns {Sprite} The sprite.
 	*/
 	sprite() {
 		return this._sprite;
 	}
 	/**
 	* Gets the base rotation.
-	* @returns {*} The baseRotation.
+	* @returns {number} The baseRotation.
 	*/
 	baseRotation() {
 		return this._baseRotation;
@@ -1978,7 +1978,7 @@ var JuiceFlipBodyMotionEffect = class extends JuiceBaseEffect {
 	}
 	/**
 	* Gets the direction sign.
-	* @returns {*} The directionSign.
+	* @returns {number} The directionSign.
 	*/
 	directionSign() {
 		return this._directionSign;
@@ -2746,7 +2746,7 @@ Sprite_Character.prototype.updatePosition = function() {
 };
 /**
 * Gets the juice flipping.
-* @returns {*} The juiceFlipping.
+* @returns {boolean} The juiceFlipping.
 */
 Sprite_Character.prototype.juiceFlipping = function() {
 	return this._juiceFlipping;

--- a/chef-adventure/js/plugins/j/abs/ext/J-ABS-Shield.js
+++ b/chef-adventure/js/plugins/j/abs/ext/J-ABS-Shield.js
@@ -1680,14 +1680,14 @@ Sprite_Character.prototype.hideShieldGauge = function() {
 };
 /**
 * Gets the shield gauge.
-* @returns {*} The shieldGauge.
+* @returns {Sprite_ShieldMapGauge|null} The shieldGauge.
 */
 Sprite_Character.prototype.shieldGauge = function() {
 	return this._j._abs._gauges._shieldGauge;
 };
 /**
 * Sets the shield gauge.
-* @param {*} newShieldGauge The new shieldGauge.
+* @param {Sprite_ShieldMapGauge|null} newShieldGauge The new shieldGauge.
 */
 Sprite_Character.prototype.setShieldGauge = function(newShieldGauge) {
 	this._j._abs._gauges._shieldGauge = newShieldGauge;
@@ -1883,7 +1883,7 @@ if (J.HUD && J.HUD.EXT.PARTY) {
 }
 /**
 * Gets the hud sprites.
-* @returns {*} The hudSprites.
+* @returns {Map<string, Sprite>} The hudSprites.
 */
 Window_PartyFrame.prototype.hudSprites = function() {
 	return this._hudSprites;

--- a/chef-adventure/js/plugins/j/abs/ext/J-ABS-Targeting.js
+++ b/chef-adventure/js/plugins/j/abs/ext/J-ABS-Targeting.js
@@ -559,77 +559,77 @@ var JABS_TargetingSentinelAction = class {
 var JABS_TargetingManager = class JABS_TargetingManager {
 	/**
 	* Gets the just began.
-	* @returns {*} The justBegan.
+	* @returns {boolean} The justBegan.
 	*/
 	static isJustBegan() {
 		return this._justBegan;
 	}
 	/**
 	* Sets the just began.
-	* @param {*} newJustBegan The new justBegan.
+	* @param {boolean} newJustBegan The new justBegan.
 	*/
 	static setJustBegan(newJustBegan) {
 		this._justBegan = newJustBegan;
 	}
 	/**
 	* Gets the session.
-	* @returns {*} The session.
+	* @returns {JABS_TargetingSession|null} The session.
 	*/
 	static session() {
 		return this._session;
 	}
 	/**
 	* Sets the session.
-	* @param {*} newSession The new session.
+	* @param {JABS_TargetingSession|null} newSession The new session.
 	*/
 	static setSession(newSession) {
 		this._session = newSession;
 	}
 	/**
 	* Gets the cursor.
-	* @returns {*} The cursor.
+	* @returns {JABS_TargetingCursor|null} The cursor.
 	*/
 	static cursor() {
 		return this._cursor;
 	}
 	/**
 	* Sets the cursor.
-	* @param {*} newCursor The new cursor.
+	* @param {JABS_TargetingCursor|null} newCursor The new cursor.
 	*/
 	static setCursor(newCursor) {
 		this._cursor = newCursor;
 	}
 	/**
 	* Gets the sentinel.
-	* @returns {*} The sentinel.
+	* @returns {JABS_TargetingSentinelAction} The sentinel.
 	*/
 	static sentinel() {
 		return this._sentinel;
 	}
 	/**
 	* Gets the previous dir8.
-	* @returns {*} The previousDir8.
+	* @returns {number} The previousDir8.
 	*/
 	static previousDir8() {
 		return this._previousDir8;
 	}
 	/**
 	* Sets the previous dir8.
-	* @param {*} newPreviousDir8 The new previousDir8.
+	* @param {number} newPreviousDir8 The new previousDir8.
 	*/
 	static setPreviousDir8(newPreviousDir8) {
 		this._previousDir8 = newPreviousDir8;
 	}
 	/**
 	* Gets the previous dpad step.
-	* @returns {*} The previousDpadStep.
+	* @returns {number} The previousDpadStep.
 	*/
 	static previousDpadStep() {
 		return this._previousDpadStep;
 	}
 	/**
 	* Sets the previous dpad step.
-	* @param {*} newPreviousDpadStep The new previousDpadStep.
+	* @param {number} newPreviousDpadStep The new previousDpadStep.
 	*/
 	static setPreviousDpadStep(newPreviousDpadStep) {
 		this._previousDpadStep = newPreviousDpadStep;
@@ -1125,7 +1125,7 @@ Game_Player.prototype.canMove = function() {
 var Window_TargetingList = class Window_TargetingList extends Window_Command {
 	/**
 	* Gets the candidates.
-	* @returns {*} The candidates.
+	* @returns {JABS_Battler[]} The candidates.
 	*/
 	candidates() {
 		return this._candidates;
@@ -1473,42 +1473,42 @@ Spriteset_Map.prototype.setReticle = function(newReticle) {
 };
 /**
 * Gets the highlight sprites.
-* @returns {*} The highlightSprites.
+* @returns {Record<string, Sprite>} The highlightSprites.
 */
 Spriteset_Map.prototype.highlightSprites = function() {
 	return this._j._targeting._highlightSprites;
 };
 /**
 * Sets the highlight sprites.
-* @param {*} newHighlightSprites The new highlightSprites.
+* @param {Record<string, Sprite>} newHighlightSprites The new highlightSprites.
 */
 Spriteset_Map.prototype.setHighlightSprites = function(newHighlightSprites) {
 	this._j._targeting._highlightSprites = newHighlightSprites;
 };
 /**
 * Gets the preview pulse.
-* @returns {*} The previewPulse.
+* @returns {Sprite_HitboxPulse|null} The previewPulse.
 */
 Spriteset_Map.prototype.previewPulse = function() {
 	return this._j._targeting._previewPulse;
 };
 /**
 * Sets the preview pulse.
-* @param {*} newPreviewPulse The new previewPulse.
+* @param {Sprite_HitboxPulse|null} newPreviewPulse The new previewPulse.
 */
 Spriteset_Map.prototype.setPreviewPulse = function(newPreviewPulse) {
 	this._j._targeting._previewPulse = newPreviewPulse;
 };
 /**
 * Gets the range ring.
-* @returns {*} The rangeRing.
+* @returns {Sprite_HitboxPulse|null} The rangeRing.
 */
 Spriteset_Map.prototype.rangeRing = function() {
 	return this._j._targeting._rangeRing;
 };
 /**
 * Sets the range ring.
-* @param {*} newRangeRing The new rangeRing.
+* @param {Sprite_HitboxPulse|null} newRangeRing The new rangeRing.
 */
 Spriteset_Map.prototype.setRangeRing = function(newRangeRing) {
 	this._j._targeting._rangeRing = newRangeRing;
@@ -1591,14 +1591,14 @@ Scene_Map.prototype.setTargetingListWindow = function(newTargetingListWindow) {
 };
 /**
 * Gets the targeting was active.
-* @returns {*} The targetingWasActive.
+* @returns {boolean} The targetingWasActive.
 */
 Scene_Map.prototype.targetingWasActive = function() {
 	return this._targetingWasActive;
 };
 /**
 * Sets the targeting was active.
-* @param {*} newTargetingWasActive The new targetingWasActive.
+* @param {boolean} newTargetingWasActive The new targetingWasActive.
 */
 Scene_Map.prototype.setTargetingWasActive = function(newTargetingWasActive) {
 	this._targetingWasActive = newTargetingWasActive;

--- a/chef-adventure/js/plugins/j/apt/J-Aptitude-Typed.js
+++ b/chef-adventure/js/plugins/j/apt/J-Aptitude-Typed.js
@@ -693,7 +693,7 @@ Game_Temp.prototype.setAptTypedInferredEnemyTypes = function(enemyId, ids) {
 };
 /**
 * Gets the apt typed inferred enemy types.
-* @returns {*} The aptTypedInferredEnemyTypes.
+* @returns {Record<number, number[]>} The aptTypedInferredEnemyTypes.
 */
 Game_Temp.prototype.aptTypedInferredEnemyTypes = function() {
 	return this._j._apt._typed._aptTypedInferredEnemyTypes;

--- a/chef-adventure/js/plugins/j/apt/J-Aptitude.js
+++ b/chef-adventure/js/plugins/j/apt/J-Aptitude.js
@@ -2297,7 +2297,10 @@ var Scene_Aptitude = class Scene_Aptitude extends Scene_ActorFacetBase {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_aptitude: {_lastAggregateIndexByActor: object, _lastSourceIndexByActor: object,
+	* _viewMode: string, _aggregates: Array, _sources: Array,
+	* _windows: {_aggregateList: Window_Base|null, _sourceList: Window_Base|null,
+	* _aggregateDetails: Window_Base|null, _sourceDetails: Window_Base|null}}}} The j.
 	*/
 	j() {
 		return this._j;

--- a/chef-adventure/js/plugins/j/base/J-Base.js
+++ b/chef-adventure/js/plugins/j/base/J-Base.js
@@ -327,7 +327,7 @@
 var JCache = class JCache {
 	/**
 	* Gets the battler caches.
-	* @returns {*} The battlerCaches.
+	* @returns {Set<JCache>} The battlerCaches.
 	*/
 	static battlerCaches() {
 		return this._battlerCaches;
@@ -362,7 +362,7 @@ var JCache = class JCache {
 	*/
 	static invalidateAllForBattler(battler) {
 		for (const cache of this.battlerCaches()) {
-			cache.invalidate(battler);
+			cache.invalidate([battler]);
 		}
 	}
 	/**
@@ -434,17 +434,21 @@ var JCache = class JCache {
 	}
 	/**
 	* Reads the cached value for the given dimension keys + string key, computing and storing it on
-	* a miss. Call shape is `get(...weakKeys, stringKey, computeFn)`, where `weakKeys.length` must
-	* equal `this.dims.length`.
-	* @param {...*} args The weak dimension keys, followed by the string key, followed by the compute function.
+	* a miss.
+	*
+	* The weak keys arrive as one array rather than as leading arguments so the call site states how
+	* many dimensions it is addressing. Spread across the argument list, `get(a, b, key, fn)` and
+	* `get(a, key, fn)` read identically, and telling them apart meant knowing the dimension count
+	* this cache was constructed with- which is declared in an entirely different file.
+	* @param {object[]} weakKeys The weak dimension keys, outermost first; length must equal `dims`.
+	* @param {string} stableKey The stable string key within the innermost bucket.
+	* @param {Function} computeFn Produces the value on a miss.
 	* @returns {any} The cached or freshly computed value.
 	*/
-	get(...args) {
-		const computeFn = args.pop();
-		const stringKey = args.pop();
+	get(weakKeys, stableKey, computeFn) {
 		let node = this.root();
 		for (let i = 0; i < this.dims.length; i++) {
-			const k = this.#resolve(this.dims[i], args[i]);
+			const k = this.#resolve(this.dims[i], weakKeys[i]);
 			let next = node.get(k);
 			if (!next) {
 				next = i === this.dims.length - 1 ? new Map() : new WeakMap();
@@ -452,23 +456,23 @@ var JCache = class JCache {
 			}
 			node = next;
 		}
-		if (node.has(stringKey) === false) {
+		if (node.has(stableKey) === false) {
 			this.recordMiss();
-			node.set(stringKey, computeFn());
+			node.set(stableKey, computeFn());
 		} else {
 			this.recordHit();
 		}
-		return node.get(stringKey);
+		return node.get(stableKey);
 	}
 	/**
-	* Drops the cached subtree at the given dimension-key prefix. `invalidate(battler)` (a
+	* Drops the cached subtree at the given dimension-key prefix. `invalidate([battler])` (a
 	* one-element prefix) is the common case: it drops every entry nested under that battler,
-	* regardless of how many further dimensions this cache declares. Calling with zero arguments
-	* clears the entire cache.
-	* @param {...object} prefix The dimension keys identifying the subtree to drop, outermost first.
+	* regardless of how many further dimensions this cache declares. An empty prefix clears the
+	* entire cache.
+	* @param {object[]=} prefix The dimension keys identifying the subtree to drop, outermost first.
 	* @returns {boolean} True if something was found and removed at that prefix, false otherwise.
 	*/
-	invalidate(...prefix) {
+	invalidate(prefix = []) {
 		if (prefix.length === 0) {
 			this.clear();
 			return true;
@@ -644,14 +648,14 @@ var ArrayHelper = class {
 var RPGManager = class RPGManager {
 	/**
 	* Gets the note cache.
-	* @returns {*} The noteCache.
+	* @returns {JCache} The noteCache.
 	*/
 	static noteCache() {
 		return this._noteCache;
 	}
 	/**
 	* Gets the eval cache.
-	* @returns {*} The evalCache.
+	* @returns {JCache} The evalCache.
 	*/
 	static evalCache() {
 		return this._evalCache;
@@ -703,7 +707,7 @@ var RPGManager = class RPGManager {
 	* @returns {any} The cached data for the object and tag key.
 	*/
 	static cached(object, tagKey, computeFn) {
-		return this.noteCache().get(object, tagKey, computeFn);
+		return this.noteCache().get([object], tagKey, computeFn);
 	}
 	/**
 	* Battler-scoped variant of {@link cached}: results are bucketed by the battler whose live
@@ -716,7 +720,7 @@ var RPGManager = class RPGManager {
 	* @returns {any}
 	*/
 	static cachedForBattler(battler, object, tagKey, computeFn) {
-		return this.evalCache().get(battler, object, tagKey, computeFn);
+		return this.evalCache().get([battler, object], tagKey, computeFn);
 	}
 	/**
 	* Invalidates the cache for the given object.
@@ -724,7 +728,7 @@ var RPGManager = class RPGManager {
 	* @returns {boolean} True if the cache was invalidated, false otherwise.
 	*/
 	static invalidate(object) {
-		return this.noteCache().invalidate(object);
+		return this.noteCache().invalidate([object]);
 	}
 	/**
 	* Drops all cached eval results for one battler. Called from Game_Battler#onBattlerDataChange
@@ -733,7 +737,7 @@ var RPGManager = class RPGManager {
 	* @returns {boolean}
 	*/
 	static invalidateBattlerEval(battler) {
-		return this.evalCache().invalidate(battler);
+		return this.evalCache().invalidate([battler]);
 	}
 	/**
 	* Clears the cache for all objects.
@@ -2070,7 +2074,7 @@ J.BASE.Helpers.maskString = function(stringToMask, maskingCharacter = "?") {
 var SerializableRegistry = class {
 	/**
 	* Gets the constructors.
-	* @returns {*} The constructors.
+	* @returns {Map<string, Function>} The constructors.
 	*/
 	static constructors() {
 		return this._constructors;
@@ -3022,7 +3026,7 @@ var BuiltWindowCommand = class {
 	/**
 	* The underlying data associated with this command.
 	* Usually populated with whatever this command represents data-wise.
-	* @type {null|any}
+	* @type {object|null}
 	*/
 	#extensionData = null;
 	/**
@@ -3135,7 +3139,7 @@ var BuiltWindowCommand = class {
 	}
 	/**
 	* Gets the underlying extension data for this command, if any is available.
-	* @returns {*|null}
+	* @returns {object|null}
 	*/
 	get ext() {
 		return this.#extensionData;
@@ -5009,14 +5013,14 @@ ParameterDefinition.Builder = () => new ParameterDefinitionBuilder();
 var ParameterRegistry = class {
 	/**
 	* Gets the definitions.
-	* @returns {*} The definitions.
+	* @returns {Map<string, ParameterDefinition>} The definitions.
 	*/
 	static definitions() {
 		return this._definitions;
 	}
 	/**
 	* Gets the group cache.
-	* @returns {*} The groupCache.
+	* @returns {Map<string, ParameterDefinition[]>} The groupCache.
 	*/
 	static groupCache() {
 		return this._groupCache;
@@ -8521,7 +8525,8 @@ Game_Action.formulaContextProviders = [];
 * The return value of the getter becomes the value of `name` inside every
 * formula evaluated by {@link Game_Action#evalFormulaWithContext}.
 * @param {string} name The variable name exposed inside the formula (e.g. `'p'`, `'s'`).
-* @param {function(Game_Action, Game_Battler, Game_Battler): *} getter A function returning the value.
+* @param {function(Game_Action, Game_Battler, Game_Battler): number|string|boolean|object} getter
+* A function returning the value exposed under `name`.
 */
 Game_Action.registerFormulaContext = function(name, getter) {
 	Game_Action.formulaContextProviders.push({
@@ -8693,42 +8698,42 @@ Game_Action.prototype.setSubjectEnemyIndex = function(newSubjectEnemyIndex) {
 };
 /**
 * Gets the trigger hp damage.
-* @returns {*} The triggerHpDamage.
+* @returns {number} The triggerHpDamage.
 */
 Game_Action.prototype.triggerHpDamage = function() {
 	return this._triggerHpDamage;
 };
 /**
 * Sets the trigger hp damage.
-* @param {*} newTriggerHpDamage The new triggerHpDamage.
+* @param {number} newTriggerHpDamage The new triggerHpDamage.
 */
 Game_Action.prototype.setTriggerHpDamage = function(newTriggerHpDamage) {
 	this._triggerHpDamage = newTriggerHpDamage;
 };
 /**
 * Gets the trigger mp damage.
-* @returns {*} The triggerMpDamage.
+* @returns {number} The triggerMpDamage.
 */
 Game_Action.prototype.triggerMpDamage = function() {
 	return this._triggerMpDamage;
 };
 /**
 * Sets the trigger mp damage.
-* @param {*} newTriggerMpDamage The new triggerMpDamage.
+* @param {number} newTriggerMpDamage The new triggerMpDamage.
 */
 Game_Action.prototype.setTriggerMpDamage = function(newTriggerMpDamage) {
 	this._triggerMpDamage = newTriggerMpDamage;
 };
 /**
 * Gets the trigger tp damage.
-* @returns {*} The triggerTpDamage.
+* @returns {number} The triggerTpDamage.
 */
 Game_Action.prototype.triggerTpDamage = function() {
 	return this._triggerTpDamage;
 };
 /**
 * Sets the trigger tp damage.
-* @param {*} newTriggerTpDamage The new triggerTpDamage.
+* @param {number} newTriggerTpDamage The new triggerTpDamage.
 */
 Game_Action.prototype.setTriggerTpDamage = function(newTriggerTpDamage) {
 	this._triggerTpDamage = newTriggerTpDamage;
@@ -9551,7 +9556,7 @@ Game_Battler.prototype.setCachedHarFactor = function(value) {
 };
 /**
 * Gets the test note sources.
-* @returns {*} The testNoteSources.
+* @returns {{note: string}[]} The testNoteSources.
 */
 Game_Battler.prototype.testNoteSources = function() {
 	return this.__testNoteSources;
@@ -10472,7 +10477,7 @@ Game_Item.prototype.setDataClass = function(newDataClass) {
 //#region src/plugins/_base/core/objects/Game_Interpreter.js
 /**
 * Gets the conditional branch results by indent depth.
-* @returns {Object<number, *>} The branch.
+* @returns {Object<number, number|boolean>} The branch.
 */
 Game_Interpreter.prototype.branch = function() {
 	return this._branch;
@@ -11928,7 +11933,9 @@ var Sprite_BaseText = class Sprite_BaseText extends Sprite {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_testBitmap: Bitmap, _text: string, _color: string, _alignment: string,
+	* _italics: boolean, _bold: boolean, _fontFace: string, _fontSize: number, _minWidth: number,
+	* _disableManagedOpacity: boolean}} The j.
 	*/
 	j() {
 		return this._j;
@@ -12014,7 +12021,7 @@ var Sprite_BaseText = class Sprite_BaseText extends Sprite {
 	}
 	/**
 	* Gets the current color assigned to this sprite's text.
-	* @returns {string|*}
+	* @returns {string}
 	*/
 	color() {
 		return this.j()._color;
@@ -12238,11 +12245,12 @@ Sprite_Character.prototype.isErased = function() {
 var Sprite_Face = class extends Sprite {
 	/**
 	* Constructor.
-	* @param {...*} args Forwarded to {@link #initialize}.
+	* @param {string} faceName The name of the face file.
+	* @param {number} faceIndex The index of the face.
 	*/
-	constructor(...args) {
+	constructor(faceName, faceIndex) {
 		super();
-		this.initialize(...args);
+		this.initialize(faceName, faceIndex);
 	}
 	/**
 	* Runs after {@link Sprite.prototype.initialize}.
@@ -12267,7 +12275,7 @@ var Sprite_Face = class extends Sprite {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_faceName: string, _faceIndex: number}} The j.
 	*/
 	j() {
 		return this._j;
@@ -12491,7 +12499,8 @@ var Sprite_Icon = class extends Sprite {
 var Sprite_MapGauge = class extends Sprite_Gauge {
 	/**
 	* Gets the gauge.
-	* @returns {*} The gauge.
+	* @returns {{_bitmapWidth: number, _bitmapHeight: number, _gaugeHeight: number, _label: string,
+	* _value: number|null, _iconIndex: number, _iconSprite: Sprite|null, _activated: boolean}} The gauge.
 	*/
 	gauge() {
 		return this._gauge;

--- a/chef-adventure/js/plugins/j/base/ext/J-Base-Save.js
+++ b/chef-adventure/js/plugins/j/base/ext/J-Base-Save.js
@@ -868,10 +868,10 @@ var SaveEncoder = class {
 	static maxDepth = 100;
 	/**
 	* Encodes any value into its plain data form.
-	* @param {*} value The value to encode.
+	* @param {object|Array|Map|Set|string|number|boolean|null} value The value to encode.
 	* @param {string=} path The JSON path of this value, used for error context.
 	* @param {number=} depth How many levels down the graph this call sits.
-	* @returns {*} The plain data form, safe to hand to `JSON.stringify`.
+	* @returns {object|Array|string|number|boolean|null} The plain data form, safe to hand to `JSON.stringify`.
 	*/
 	static encode(value, path = "$", depth = 0) {
 		if (depth >= this.maxDepth) throw SaveEncodeError.tooDeep(path, this.maxDepth);
@@ -950,12 +950,12 @@ var SaveEncoder = class {
 	* that owns them, so once the walk descends into a namespace object those keys are no longer that
 	* codec's to police - only the transient waypoint travels down, because a transient path is
 	* explicitly written to reach that far.
-	* @param {*} child The value being encoded.
+	* @param {object|Array|Map|Set|string|number|boolean|null} child The value being encoded.
 	* @param {{value: Function|null, children: Map<string, object>}|null} childNode The child's
 	* position in the transient tree, or null when nothing below it is declared.
 	* @param {string} childPath The JSON path of the child.
 	* @param {number} depth How many levels down the graph this call sits.
-	* @returns {*} The encoded child.
+	* @returns {object|Array|string|number|boolean|null} The encoded child.
 	*/
 	static encodeChild(child, childNode, childPath, depth) {
 		if (childNode === null || childNode.children.size === 0) {
@@ -976,7 +976,7 @@ var SaveEncoder = class {
 	* It applies only to the direct keys of a registered class. A plain object has no declarations of
 	* its own, so a class instance nested inside a namespace object is checked by nothing here- what
 	* protects that case is the encoder refusing to encode an unregistered type at all.
-	* @param {*} child The value held at the field.
+	* @param {object|Array|Map|Set|string|number|boolean|null} child The value held at the field.
 	* @param {SaveCodec|null} codec The codec that owns the field, or null for a plain object.
 	* @param {string} key The field name.
 	* @param {string} childPath The JSON path of the field.
@@ -1013,11 +1013,11 @@ var SaveEncoder = class {
 var SaveDecoder = class {
 	/**
 	* Decodes plain data back into live objects.
-	* @param {*} data The plain data to decode.
+	* @param {object|Array|string|number|boolean|null} data The plain data to decode.
 	* @param {Function|null=} expectedType The constructor the containing type map declares here, or
 	* null when nothing declared it.
 	* @param {string=} path The JSON path of this value, used for error context.
-	* @returns {*} The rebuilt value.
+	* @returns {object|Array|Map|Set|string|number|boolean|null} The rebuilt value.
 	*/
 	static decode(data, expectedType = null, path = "$") {
 		if (data === null) return data;
@@ -1112,9 +1112,10 @@ var SaveDecoder = class {
 	* Merging instead means the file wins wherever it has something to say and the seeded default
 	* survives wherever it does not. Instances, arrays, `Map`s, and primitives replace outright, since
 	* a decoded instance is already the complete answer for its position.
-	* @param {*} seeded Whatever the seed left at this position, which is usually nothing.
-	* @param {*} decoded The value the file produced.
-	* @returns {*} The value to assign.
+	* @param {object|Array|Map|Set|string|number|boolean|null|undefined} seeded Whatever the seed left
+	* at this position, which is usually nothing.
+	* @param {object|Array|Map|Set|string|number|boolean|null} decoded The value the file produced.
+	* @returns {object|Array|Map|Set|string|number|boolean|null} The value to assign.
 	*/
 	static mergeOverSeeded(seeded, decoded) {
 		if (this.isPlainObject(seeded) === false) return decoded;
@@ -1126,13 +1127,13 @@ var SaveDecoder = class {
 	}
 	/**
 	* Decodes one child value against whatever its position declares.
-	* @param {*} child The plain data being decoded.
+	* @param {object|Array|string|number|boolean|null} child The plain data being decoded.
 	* @param {{value: Function|null, children: Map<string, object>}|null} typedChild The child's
 	* position in the type tree, or null.
 	* @param {{value: Function|null, children: Map<string, object>}|null} typedValuesChild The child's
 	* position in the dictionary-value type tree, or null.
 	* @param {string} childPath The JSON path of the child.
-	* @returns {*} The decoded child.
+	* @returns {object|Array|Map|Set|string|number|boolean|null} The decoded child.
 	*/
 	static decodeChild(child, typedChild, typedValuesChild, childPath) {
 		if (typedValuesChild !== null && typedValuesChild.value !== null) {
@@ -1162,7 +1163,7 @@ var SaveDecoder = class {
 	}
 	/**
 	* Determines whether a value is a plain object rather than an instance, array, or primitive.
-	* @param {*} value The value to classify.
+	* @param {object|Array|Map|Set|string|number|boolean|null|undefined} value The value to classify.
 	* @returns {boolean}
 	*/
 	static isPlainObject(value) {
@@ -1190,7 +1191,7 @@ var SaveDecoder = class {
 	* one cache, on a save written before that plugin was installed.
 	* @param {object} instance The instance to assign onto.
 	* @param {string} path The dotted path to assign at.
-	* @param {*} value The value to assign.
+	* @param {object|Array|Map|Set|string|number|boolean|null} value The value to assign.
 	*/
 	static assignAtPath(instance, path, value) {
 		const segments = path.split(".");
@@ -2701,7 +2702,7 @@ var SaveFileSystem = class {
 	* Two spaces, and no attempt at compactness: the point of this format is that a developer can open
 	* a savefile, read it, edit it, and load the result. Size is explicitly not a consideration.
 	* @param {string} filePath The path to write to.
-	* @param {*} data The plain data to serialize.
+	* @param {object} data The plain data to serialize.
 	*/
 	static writeJson(filePath, data) {
 		this.writeSynced(filePath, JSON.stringify(data, null, 2));
@@ -2752,7 +2753,7 @@ var SaveFileSystem = class {
 	* the retry loop.
 	* @param {string} slotName The slot's name.
 	* @param {Function} buildFromSections Receives `(sections, manifest)` and returns the loaded value.
-	* @returns {Promise<*>} Whatever `buildFromSections` returned for the newest generation that worked.
+	* @returns {Promise<object>} Whatever `buildFromSections` returned for the newest generation that worked.
 	*/
 	static readSlot(slotName, buildFromSections) {
 		return new Promise((resolve, reject) => {
@@ -2819,7 +2820,7 @@ var SaveFileSystem = class {
 	* @param {string} slotName The slot's name.
 	* @param {string} generationName The generation to read, ex: `gen-0007`.
 	* @param {Function} buildFromSections Receives `(sections, manifest)` and returns the loaded value.
-	* @returns {Promise<*>} Whatever `buildFromSections` returned, or a rejection carrying why not.
+	* @returns {Promise<object>} Whatever `buildFromSections` returned, or a rejection carrying why not.
 	*/
 	static readGenerationAt(slotName, generationName, buildFromSections) {
 		return new Promise((resolve, reject) => {
@@ -2835,7 +2836,7 @@ var SaveFileSystem = class {
 	* @param {string} slotName The slot's name.
 	* @param {string} generationName The generation to read.
 	* @param {Function} buildFromSections Receives `(sections, manifest)` and returns the loaded value.
-	* @returns {*} Whatever `buildFromSections` returned.
+	* @returns {object} Whatever `buildFromSections` returned.
 	*/
 	static readGeneration(slotName, generationName, buildFromSections) {
 		const manifest = this.readManifestAt(slotName, generationName);
@@ -2942,7 +2943,7 @@ var SaveFileSystem = class {
 	* A single document does not need generations; it needs the same rename that makes a generation
 	* swap safe, so a crash mid-write cannot leave the player's settings half-written.
 	* @param {string} fileName The document's file name.
-	* @param {*} data The plain data to write.
+	* @param {object} data The plain data to write.
 	* @returns {Promise<void>} Resolves once the document is on disk.
 	*/
 	static writeDocument(fileName, data) {
@@ -3416,7 +3417,7 @@ var SaveFileMode = class {
 	* Always a promise, even for the modes whose work is synchronous, so the scene has one success path
 	* and one failure path rather than a branch on which command it is running.
 	* @param {SaveFileEntry} _entry The row chosen.
-	* @returns {Promise<*>}
+	* @returns {Promise<void>}
 	*/
 	execute(_entry) {
 		return Promise.resolve();
@@ -3486,7 +3487,7 @@ var SaveFileModeSave = class extends SaveFileMode {
 	* Implements {@link SaveFileMode.execute}.<br/>
 	* Follows vanilla's own save sequence, which several plugins hang state-flushing off.
 	* @param {SaveFileEntry} entry The row chosen.
-	* @returns {Promise<*>}
+	* @returns {Promise<void>}
 	*/
 	execute(entry) {
 		$gameSystem.setSavefileId(entry.savefileId());
@@ -3573,7 +3574,7 @@ var SaveFileModeLoad = class extends SaveFileMode {
 	/**
 	* Implements {@link SaveFileMode.execute}.<br/>
 	* @param {SaveFileEntry} entry The row chosen.
-	* @returns {Promise<*>}
+	* @returns {Promise<void>}
 	*/
 	execute(entry) {
 		return DataManager.loadGame(entry.savefileId());
@@ -3651,7 +3652,7 @@ var SaveFileModeDelete = class extends SaveFileMode {
 	* so deleting the last remaining save without rebuilding it leaves Continue lit up and pointing at
 	* nothing.
 	* @param {SaveFileEntry} entry The row chosen.
-	* @returns {Promise<*>}
+	* @returns {Promise<void>}
 	*/
 	execute(entry) {
 		StorageManager.remove(entry.slotName());
@@ -3776,7 +3777,7 @@ var SaveFileModeRewind = class extends SaveFileMode {
 	* Implements {@link SaveFileMode.execute}.<br/>
 	* Loads the exact generation chosen, with no fallback to a newer one.
 	* @param {SaveFileEntry} entry The row chosen.
-	* @returns {Promise<*>}
+	* @returns {Promise<void>}
 	*/
 	execute(entry) {
 		return DataManager.loadGeneration(entry.savefileId(), entry.generationName());
@@ -5248,7 +5249,7 @@ var ProfileManager = class {
 	static _registeredFields = new Map();
 	/**
 	* The live value of every registered field.
-	* @type {Map<string, *>}
+	* @type {Map<string, object|Array|Map|Set|string|number|boolean|null>}
 	*/
 	static _values = new Map();
 	/**
@@ -5265,7 +5266,7 @@ var ProfileManager = class {
 	}
 	/**
 	* Gets the live value of every registered field.
-	* @returns {Map<string, *>} The values, keyed by field name.
+	* @returns {Map<string, object|Array|Map|Set|string|number|boolean|null>} The values, keyed by field name.
 	*/
 	static values() {
 		return this._values;
@@ -5285,7 +5286,7 @@ var ProfileManager = class {
 	/**
 	* Gets the current value of a registered field.
 	* @param {string} key The field name.
-	* @returns {*} The value.
+	* @returns {object|Array|Map|Set|string|number|boolean|null} The value.
 	*/
 	static get(key) {
 		return this.values().get(key);
@@ -5293,7 +5294,7 @@ var ProfileManager = class {
 	/**
 	* Sets the value of a registered field. Writing the document is the caller's decision.
 	* @param {string} key The field name.
-	* @param {*} value The value to hold.
+	* @param {object|Array|Map|Set|string|number|boolean|null} value The value to hold.
 	*/
 	static set(key, value) {
 		this.values().set(key, value);

--- a/chef-adventure/js/plugins/j/ca-mods/J-CA-Mods.js
+++ b/chef-adventure/js/plugins/j/ca-mods/J-CA-Mods.js
@@ -250,7 +250,7 @@ Game_Actor.prototype.extractFloorDamageRate = function(referenceData) {
 /**
 * Gets all sources that can possibly yield damage by stepping.
 * Open for extension.
-* @returns {*[]}
+* @returns {{note: string}[]}
 */
 Game_Actor.prototype.floorDamageSources = function() {
 	const sources = [];

--- a/chef-adventure/js/plugins/j/cms/ext/J-CMS-Equip.js
+++ b/chef-adventure/js/plugins/j/cms/ext/J-CMS-Equip.js
@@ -227,7 +227,7 @@ var Window_MoreEquipData = class extends Window_MoreData {
 var Window_EquipActorRibbon = class extends Window_ActorRibbon {
 	/**
 	* Gets the actor.
-	* @returns {*} The actor.
+	* @returns {Game_Actor} The actor.
 	*/
 	actor() {
 		return this._actor;

--- a/chef-adventure/js/plugins/j/diff/J-Difficulty.js
+++ b/chef-adventure/js/plugins/j/diff/J-Difficulty.js
@@ -1270,7 +1270,7 @@ Game_Temp.prototype.metadata = function() {
 };
 /**
 * Gets the all configs.
-* @returns {*} The allConfigs.
+* @returns {Map<string, DifficultyConfig>} The allConfigs.
 */
 Game_Temp.prototype.allConfigs = function() {
 	return this._j._difficulty._allConfigs;

--- a/chef-adventure/js/plugins/j/extend/J-Extend.js
+++ b/chef-adventure/js/plugins/j/extend/J-Extend.js
@@ -911,14 +911,14 @@ J.EXTEND.RegExp.ToggleGroupOnExecute = /<toggleGroupOnExecute:[ ]?(\[[^\]]+])>/g
 var OverlayManager = class OverlayManager {
 	/**
 	* Gets the skill cache.
-	* @returns {*} The skillCache.
+	* @returns {JCache} The skillCache.
 	*/
 	static skillCache() {
 		return this._skillCache;
 	}
 	/**
 	* Gets the state cache.
-	* @returns {*} The stateCache.
+	* @returns {JCache} The stateCache.
 	*/
 	static stateCache() {
 		return this._stateCache;
@@ -972,8 +972,8 @@ var OverlayManager = class OverlayManager {
 	* @returns {boolean} True if the cache was invalidated, false otherwise.
 	*/
 	static invalidate(battler) {
-		this.skillCache().invalidate(battler);
-		this.stateCache().invalidate(battler);
+		this.skillCache().invalidate([battler]);
+		this.stateCache().invalidate([battler]);
 	}
 	/**
 	* Clears the cache for all objects.
@@ -1000,7 +1000,7 @@ var OverlayManager = class OverlayManager {
 	static getExtendedSkill(caster, skillId) {
 		if (skillId <= 0) throw new Error("Invalid skill extension id.");
 		if (!caster) return this.#requireDatabaseEntry($dataSkills[skillId], "skill", skillId);
-		return this.skillCache().get(caster, String(skillId), () => {
+		return this.skillCache().get([caster], String(skillId), () => {
 			const knownIds = caster.skillIds();
 			const targetSkill = $dataSkills[skillId];
 			const targetTypes = targetSkill ? targetSkill.types() : [];
@@ -1057,7 +1057,7 @@ var OverlayManager = class OverlayManager {
 	static getExtendedState(battler, stateId) {
 		if (stateId <= 0) throw new Error("Invalid state id for extension.");
 		if (!battler) return this.#requireDatabaseEntry($dataStates[stateId], "state", stateId);
-		return this.stateCache().get(battler, String(stateId), () => {
+		return this.stateCache().get([battler], String(stateId), () => {
 			const allIds = battler.allStateIds();
 			const targetState = $dataStates[stateId];
 			const targetTypes = targetState ? targetState.types() : [];

--- a/chef-adventure/js/plugins/j/hud/J-HUD.js
+++ b/chef-adventure/js/plugins/j/hud/J-HUD.js
@@ -735,7 +735,7 @@ var Window_Frame = class extends Window_Base {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_spriteCache: Map<string, Sprite>}} The j.
 	*/
 	j() {
 		return this._j;

--- a/chef-adventure/js/plugins/j/hud/ext/J-HUD-BossFrame.js
+++ b/chef-adventure/js/plugins/j/hud/ext/J-HUD-BossFrame.js
@@ -293,7 +293,8 @@ var Window_BossFrame = class extends Window_TargetFrame {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_hud: {_boss: {_requestHide: boolean, _concealing: boolean, _requestShow: boolean,
+	* _revealing: boolean}}}} The j.
 	*/
 	j() {
 		return this._j;

--- a/chef-adventure/js/plugins/j/hud/ext/J-HUD-InputFrame.js
+++ b/chef-adventure/js/plugins/j/hud/ext/J-HUD-InputFrame.js
@@ -141,7 +141,7 @@ var Sprite_BaseSkillSlot = class extends Sprite_BaseText {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_skillSlot: JABS_SkillSlot|null}} The j.
 	*/
 	j() {
 		return this._j;
@@ -309,7 +309,7 @@ var Sprite_CooldownGauge = class extends Sprite {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_gcdMergeBattler: JABS_Battler|null, _gcdMergeSkillId: number}} The j.
 	*/
 	j() {
 		return this._j;
@@ -587,11 +587,13 @@ var Sprite_CooldownGauge = class extends Sprite {
 var Sprite_CooldownTimer = class extends Sprite {
 	/**
 	* Constructor.
-	* @param {...*} args Forwarded to {@link #initialize}.
+	* @param {string} skillType The slot's skill type key.
+	* @param {JABS_Cooldown} cooldownData The cooldown this timer reflects.
+	* @param {boolean=} isItem Whether the slot holds an item rather than a skill.
 	*/
-	constructor(...args) {
+	constructor(skillType, cooldownData, isItem = false) {
 		super();
-		this.initialize(...args);
+		this.initialize(skillType, cooldownData, isItem);
 	}
 	/**
 	* Initializes this cooldown timer sprite.
@@ -618,7 +620,7 @@ var Sprite_CooldownTimer = class extends Sprite {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_skillType: string, _cooldownData: JABS_Cooldown, _isItem: boolean}} The j.
 	*/
 	j() {
 		return this._j;
@@ -902,7 +904,8 @@ var Sprite_SkillSlotIcon = class extends Sprite_Icon {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_skillSlot: JABS_SkillSlot|null, _cooldownOverlaySprite: Sprite|null,
+	* _prevBaseReady: boolean, _prevComboReady: boolean, _pulseFrames: number}} The j.
 	*/
 	j() {
 		return this._j;
@@ -1114,7 +1117,8 @@ var Sprite_InputKeySlot = class extends Sprite {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_skillSlot: JABS_SkillSlot|null, _battler: JABS_Battler|null,
+	* _spriteCache: Map<string, Sprite>}} The j.
 	*/
 	j() {
 		return this._j;
@@ -1650,7 +1654,9 @@ var Window_InputFrame = class Window_InputFrame extends Window_Frame {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_battler: JABS_Battler|null, _needsRefresh: boolean,
+	* _last: {_skillTriggerHeld: boolean, _partyInCombat: boolean},
+	* _flip: {_progress: number, _max: number, _direction: number}}} The j.
 	*/
 	j() {
 		return this._j;

--- a/chef-adventure/js/plugins/j/hud/ext/J-HUD-PartyFrame.js
+++ b/chef-adventure/js/plugins/j/hud/ext/J-HUD-PartyFrame.js
@@ -800,7 +800,9 @@ var Sprite_ActorValue = class extends Sprite {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_parameter: string, _actor: Game_Actor, _fontSizeMod: number,
+	* _last: {_hp: number, _mp: number, _tp: number, _xp: number, _lvl: number},
+	* _autoCounter: number}} The j.
 	*/
 	j() {
 		return this._j;
@@ -1108,14 +1110,14 @@ Scene_Map.prototype.handleRefreshPartyFrameImageCache = function() {
 };
 /**
 * Gets the party frame.
-* @returns {*} The partyFrame.
+* @returns {Window_PartyFrame} The partyFrame.
 */
 Scene_Map.prototype.partyFrame = function() {
 	return this._j._partyFrame;
 };
 /**
 * Sets the party frame.
-* @param {*} newPartyFrame The new partyFrame.
+* @param {Window_PartyFrame} newPartyFrame The new partyFrame.
 */
 Scene_Map.prototype.setPartyFrame = function(newPartyFrame) {
 	this._j._partyFrame = newPartyFrame;

--- a/chef-adventure/js/plugins/j/hud/ext/J-HUD-TargetFrame.js
+++ b/chef-adventure/js/plugins/j/hud/ext/J-HUD-TargetFrame.js
@@ -703,7 +703,7 @@ var FramedTarget = class {
 var Sprite_FlowingGauge = class Sprite_FlowingGauge extends Sprite {
 	/**
 	* Gets the background bitmap.
-	* @returns {*} The backgroundBitmap.
+	* @returns {Bitmap|null} The backgroundBitmap.
 	*/
 	backgroundBitmap() {
 		return this._backgroundBitmap;
@@ -871,14 +871,14 @@ var Sprite_FlowingGauge = class Sprite_FlowingGauge extends Sprite {
 	}
 	/**
 	* Gets the gauge actual flow limit.
-	* @returns {*} The gaugeActualFlowLimit.
+	* @returns {number} The gaugeActualFlowLimit.
 	*/
 	gaugeActualFlowLimit() {
 		return this._gaugeActualFlowLimit;
 	}
 	/**
 	* Sets the gauge actual flow limit.
-	* @param {*} newGaugeActualFlowLimit The new gaugeActualFlowLimit.
+	* @param {number} newGaugeActualFlowLimit The new gaugeActualFlowLimit.
 	*/
 	setGaugeActualFlowLimit(newGaugeActualFlowLimit) {
 		this._gaugeActualFlowLimit = newGaugeActualFlowLimit;
@@ -2031,7 +2031,9 @@ var Window_TargetFrame = class Window_TargetFrame extends Window_Base {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_spriteCache: Map<string, Sprite>, _name: string, _nameColorHex: string, _text: string,
+	* _icon: number, _battler: Game_Battler|null, _requestTargetRefresh: boolean,
+	* _inactivityTimer: number}} The j.
 	*/
 	j() {
 		return this._j;
@@ -2509,7 +2511,7 @@ if (J.HUD && J.HUD.EXT.TARGET) {
 }
 /**
 * Gets the affliction presenter.
-* @returns {*} The afflictionPresenter.
+* @returns {StateAfflictionHudPresenter} The afflictionPresenter.
 */
 Window_TargetFrame.prototype.afflictionPresenter = function() {
 	return this._afflictionPresenter;
@@ -2523,7 +2525,7 @@ Window_TargetFrame.prototype.battler = function() {
 };
 /**
 * Gets the inactivity timer.
-* @returns {*} The inactivityTimer.
+* @returns {number} The inactivityTimer.
 */
 Window_TargetFrame.prototype.inactivityTimer = function() {
 	return this._j._inactivityTimer;

--- a/chef-adventure/js/plugins/j/jafting/J-JAFTING.js
+++ b/chef-adventure/js/plugins/j/jafting/J-JAFTING.js
@@ -1310,7 +1310,7 @@ var Window_SalvageConfirmation = class extends Window_Command {
 var Window_SalvagePreview = class Window_SalvagePreview extends Window_Base {
 	/**
 	* Gets the refund two column.
-	* @returns {*} The refundTwoColumn.
+	* @returns {boolean} The refundTwoColumn.
 	*/
 	/**
 	* Gets the dismantle amount.
@@ -1321,7 +1321,7 @@ var Window_SalvagePreview = class Window_SalvagePreview extends Window_Base {
 	}
 	/**
 	* Gets the datum.
-	* @returns {*} The datum.
+	* @returns {RPG_Item|RPG_Weapon|RPG_Armor|null} The datum.
 	*/
 	datum() {
 		return this._datum;
@@ -1334,7 +1334,7 @@ var Window_SalvagePreview = class Window_SalvagePreview extends Window_Base {
 	}
 	/**
 	* Sets the refund two column.
-	* @param {*} newRefundTwoColumn The new refundTwoColumn.
+	* @param {boolean} newRefundTwoColumn The new refundTwoColumn.
 	*/
 	setRefundTwoColumn(newRefundTwoColumn) {
 		this._refundTwoColumn = newRefundTwoColumn;
@@ -1595,28 +1595,28 @@ var Window_SalvagePreview = class Window_SalvagePreview extends Window_Base {
 var Scene_JaftingSalvage = class Scene_JaftingSalvage extends Scene_MenuBase {
 	/**
 	* Gets the last preview datum.
-	* @returns {*} The lastPreviewDatum.
+	* @returns {RPG_Item|RPG_Weapon|RPG_Armor|null} The lastPreviewDatum.
 	*/
 	lastPreviewDatum() {
 		return this._lastPreviewDatum;
 	}
 	/**
 	* Sets the last preview datum.
-	* @param {*} newLastPreviewDatum The new lastPreviewDatum.
+	* @param {RPG_Item|RPG_Weapon|RPG_Armor|null} newLastPreviewDatum The new lastPreviewDatum.
 	*/
 	setLastPreviewDatum(newLastPreviewDatum) {
 		this._lastPreviewDatum = newLastPreviewDatum;
 	}
 	/**
 	* Gets the last preview stack.
-	* @returns {*} The lastPreviewStack.
+	* @returns {number|null} The lastPreviewStack.
 	*/
 	lastPreviewStack() {
 		return this._lastPreviewStack;
 	}
 	/**
 	* Sets the last preview stack.
-	* @param {*} newLastPreviewStack The new lastPreviewStack.
+	* @param {number|null} newLastPreviewStack The new lastPreviewStack.
 	*/
 	setLastPreviewStack(newLastPreviewStack) {
 		this._lastPreviewStack = newLastPreviewStack;

--- a/chef-adventure/js/plugins/j/jafting/ext/J-JAFTING-Creation.js
+++ b/chef-adventure/js/plugins/j/jafting/ext/J-JAFTING-Creation.js
@@ -1611,7 +1611,7 @@ Game_Party.prototype.unlockEverythingCompletely = function() {
 	this.unlockAllCategories();
 	this.revealAllKnownRecipes();
 };
-Game_Party.prototype.updateVariableWithCraftedCountByCategories = function(variableId, ...categoryKeys) {
+Game_Party.prototype.updateVariableWithCraftedCountByCategories = function(variableId, categoryKeys) {
 	let count = 0;
 	categoryKeys.forEach((categoryKey) => {
 		count += this.getCraftedRecipeCountByCategoryKey(categoryKey);
@@ -1620,28 +1620,28 @@ Game_Party.prototype.updateVariableWithCraftedCountByCategories = function(varia
 };
 /**
 * Gets the recipe trackings.
-* @returns {*} The recipeTrackings.
+* @returns {RecipeTracking[]} The recipeTrackings.
 */
 Game_Party.prototype.recipeTrackings = function() {
 	return this._j._crafting._recipeTrackings;
 };
 /**
 * Sets the recipe trackings.
-* @param {*} newRecipeTrackings The new recipeTrackings.
+* @param {RecipeTracking[]} newRecipeTrackings The new recipeTrackings.
 */
 Game_Party.prototype.setRecipeTrackings = function(newRecipeTrackings) {
 	this._j._crafting._recipeTrackings = newRecipeTrackings;
 };
 /**
 * Gets the category trackings.
-* @returns {*} The categoryTrackings.
+* @returns {CategoryTracking[]} The categoryTrackings.
 */
 Game_Party.prototype.categoryTrackings = function() {
 	return this._j._crafting._categoryTrackings;
 };
 /**
 * Sets the category trackings.
-* @param {*} newCategoryTrackings The new categoryTrackings.
+* @param {CategoryTracking[]} newCategoryTrackings The new categoryTrackings.
 */
 Game_Party.prototype.setCategoryTrackings = function(newCategoryTrackings) {
 	this._j._crafting._categoryTrackings = newCategoryTrackings;

--- a/chef-adventure/js/plugins/j/jafting/ext/J-JAFTING-Refinement.js
+++ b/chef-adventure/js/plugins/j/jafting/ext/J-JAFTING-Refinement.js
@@ -223,7 +223,7 @@
 var JAFTING_Trait = class {
 	/**
 	* Gets the code.
-	* @returns {*} The code.
+	* @returns {number} The code.
 	*/
 	code() {
 		return this._code;
@@ -295,7 +295,7 @@ var JAFTING_Trait = class {
 var JAFTING_RefinementData = class {
 	/**
 	* Gets the notes.
-	* @returns {*} The notes.
+	* @returns {string[]} The notes.
 	*/
 	notes() {
 		return this._notes;

--- a/chef-adventure/js/plugins/j/level/J-LevelMaster.js
+++ b/chef-adventure/js/plugins/j/level/J-LevelMaster.js
@@ -1388,7 +1388,7 @@ Game_Enemy.prototype.getLevelBalancer = function() {
 };
 /**
 * Gets the skill learnings.
-* @returns {*} The skillLearnings.
+* @returns {Record<number, number>} The skillLearnings.
 */
 Game_Enemy.prototype.skillLearnings = function() {
 	return this._j._level._skillLearnings;

--- a/chef-adventure/js/plugins/j/level/ext/J-Level-Sync.js
+++ b/chef-adventure/js/plugins/j/level/ext/J-Level-Sync.js
@@ -435,14 +435,14 @@ Game_Map.prototype.setContentSyncLevel = function(newContentSyncLevel) {
 };
 /**
 * Gets the content sync uplevel.
-* @returns {*} The contentSyncUplevel.
+* @returns {boolean} The contentSyncUplevel.
 */
 Game_Map.prototype.contentSyncUplevel = function() {
 	return this._j._levelSync._contentSyncUplevel;
 };
 /**
 * Sets the content sync uplevel.
-* @param {*} newContentSyncUplevel The new contentSyncUplevel.
+* @param {boolean} newContentSyncUplevel The new contentSyncUplevel.
 */
 Game_Map.prototype.setContentSyncUplevel = function(newContentSyncUplevel) {
 	this._j._levelSync._contentSyncUplevel = newContentSyncUplevel;

--- a/chef-adventure/js/plugins/j/map/J-Map.js
+++ b/chef-adventure/js/plugins/j/map/J-Map.js
@@ -738,7 +738,7 @@ var Sprite_MiniMap = class extends Sprite {
 	}
 	/**
 	* Gets the focus mode.
-	* @returns {*} The focusMode.
+	* @returns {boolean} The focusMode.
 	*/
 	isFocusMode() {
 		return this._focusMode;
@@ -766,28 +766,28 @@ var Sprite_MiniMap = class extends Sprite {
 	}
 	/**
 	* Gets the smooth fx.
-	* @returns {*} The smoothFx.
+	* @returns {number} The smoothFx.
 	*/
 	smoothFx() {
 		return this._smoothFx;
 	}
 	/**
 	* Sets the smooth fx.
-	* @param {*} newSmoothFx The new smoothFx.
+	* @param {number} newSmoothFx The new smoothFx.
 	*/
 	setSmoothFx(newSmoothFx) {
 		this._smoothFx = newSmoothFx;
 	}
 	/**
 	* Gets the smooth fy.
-	* @returns {*} The smoothFy.
+	* @returns {number} The smoothFy.
 	*/
 	smoothFy() {
 		return this._smoothFy;
 	}
 	/**
 	* Sets the smooth fy.
-	* @param {*} newSmoothFy The new smoothFy.
+	* @param {number} newSmoothFy The new smoothFy.
 	*/
 	setSmoothFy(newSmoothFy) {
 		this._smoothFy = newSmoothFy;
@@ -829,14 +829,16 @@ var Sprite_MiniMap = class extends Sprite {
 	}
 	/**
 	* Gets the pre focus state.
-	* @returns {*} The preFocusState.
+	* @returns {{mapRange: number, scale: number, width: number, height: number, x: number, y: number,
+	* smoothFx: number, smoothFy: number}|null} The preFocusState.
 	*/
 	preFocusState() {
 		return this._preFocusState;
 	}
 	/**
 	* Sets the pre focus state.
-	* @param {*} newPreFocusState The new preFocusState.
+	* @param {{mapRange: number, scale: number, width: number, height: number, x: number, y: number,
+	* smoothFx: number, smoothFy: number}|null} newPreFocusState The new preFocusState.
 	*/
 	setPreFocusState(newPreFocusState) {
 		this._preFocusState = newPreFocusState;
@@ -2142,7 +2144,7 @@ if (J.ABS) {
 }
 /**
 * Gets the minimap focus pressed prev.
-* @returns {*} The minimapFocusPressedPrev.
+* @returns {boolean} The minimapFocusPressedPrev.
 */
 JABS_StandardController.prototype.minimapFocusPressedPrev = function() {
 	return this._minimapFocusPressedPrev;

--- a/chef-adventure/js/plugins/j/message/J-MessageTextCodes.js
+++ b/chef-adventure/js/plugins/j/message/J-MessageTextCodes.js
@@ -303,28 +303,28 @@ Game_Message.prototype.hideChoice = function(choiceIndex, isHidden) {
 };
 /**
 * Gets the hidden choice conditions.
-* @returns {*} The hiddenChoiceConditions.
+* @returns {Map<number, boolean>} The hiddenChoiceConditions.
 */
 Game_Message.prototype.hiddenChoiceConditions = function() {
 	return this._hiddenChoiceConditions;
 };
 /**
 * Sets the hidden choice conditions.
-* @param {*} newHiddenChoiceConditions The new hiddenChoiceConditions.
+* @param {Map<number, boolean>} newHiddenChoiceConditions The new hiddenChoiceConditions.
 */
 Game_Message.prototype.setHiddenChoiceConditions = function(newHiddenChoiceConditions) {
 	this._hiddenChoiceConditions = newHiddenChoiceConditions;
 };
 /**
 * Gets the old choices.
-* @returns {*} The oldChoices.
+* @returns {string[]} The oldChoices.
 */
 Game_Message.prototype.oldChoices = function() {
 	return this._oldChoices;
 };
 /**
 * Sets the old choices.
-* @param {*} newOldChoices The new oldChoices.
+* @param {string[]} newOldChoices The new oldChoices.
 */
 Game_Message.prototype.setOldChoices = function(newOldChoices) {
 	this._oldChoices = newOldChoices;
@@ -493,7 +493,7 @@ Window_Base.prototype.convertEscapeCharacters = function(text) {
 /**
 * Translates the text code into the name and icon of the weapon.
 * @param {string} text The text that has a text code in it.
-* @returns {*}
+* @returns {string}
 */
 Window_Base.prototype.translateWeaponTextCode = function(text) {
 	return text.replace(/\\weapon\[(\d+)]/gi, (_, p1) => {
@@ -730,14 +730,14 @@ Window_ChoiceList.prototype.callOkHandler = function() {
 };
 /**
 * Gets the choice map.
-* @returns {*} The choiceMap.
+* @returns {number[]} The choiceMap.
 */
 Window_ChoiceList.prototype.choiceMap = function() {
 	return this._choiceMap;
 };
 /**
 * Sets the choice map.
-* @param {*} newChoiceMap The new choiceMap.
+* @param {number[]} newChoiceMap The new choiceMap.
 */
 Window_ChoiceList.prototype.setChoiceMap = function(newChoiceMap) {
 	this._choiceMap = newChoiceMap;

--- a/chef-adventure/js/plugins/j/natural/J-NaturalGrowth.js
+++ b/chef-adventure/js/plugins/j/natural/J-NaturalGrowth.js
@@ -535,7 +535,7 @@ Game_Battler.prototype.initNaturalGrowthParameters = function() {
 	this._j._natural._harBuffRate = 0;
 	/**
 	* The permanent flat bonuses for each of the base parameters.
-	* @type {number[]}
+	* @type {[number, number, number, number, number, number, number, number]}
 	*/
 	this._j._natural._bParamsGrowthPlus = [
 		0,
@@ -549,7 +549,7 @@ Game_Battler.prototype.initNaturalGrowthParameters = function() {
 	];
 	/**
 	* The permanent multiplier bonuses for each of the base parameters.
-	* @type {number[]}
+	* @type {[number, number, number, number, number, number, number, number]}
 	*/
 	this._j._natural._bParamsGrowthRate = [
 		0,
@@ -563,7 +563,7 @@ Game_Battler.prototype.initNaturalGrowthParameters = function() {
 	];
 	/**
 	* The cache of temporary flat bonuses for each of the base parameters.
-	* @type {number[]}
+	* @type {[number, number, number, number, number, number, number, number]}
 	*/
 	this._j._natural._bParamsBuffPlus = [
 		0,
@@ -577,7 +577,7 @@ Game_Battler.prototype.initNaturalGrowthParameters = function() {
 	];
 	/**
 	* The cache of temporary multiplier bonuses for each of the base parameters.
-	* @type {number[]}
+	* @type {[number, number, number, number, number, number, number, number]}
 	*/
 	this._j._natural._bParamsBuffRate = [
 		0,
@@ -591,7 +591,7 @@ Game_Battler.prototype.initNaturalGrowthParameters = function() {
 	];
 	/**
 	* The permanent flat bonuses for each of the sp-parameters.
-	* @type {number[]}
+	* @type {[number, number, number, number, number, number, number, number, number, number]}
 	*/
 	this._j._natural._sParamsGrowthPlus = [
 		0,
@@ -607,7 +607,7 @@ Game_Battler.prototype.initNaturalGrowthParameters = function() {
 	];
 	/**
 	* The permanent multiplier bonuses for each of the sp-parameters.
-	* @type {number[]}
+	* @type {[number, number, number, number, number, number, number, number, number, number]}
 	*/
 	this._j._natural._sParamsGrowthRate = [
 		0,
@@ -623,7 +623,7 @@ Game_Battler.prototype.initNaturalGrowthParameters = function() {
 	];
 	/**
 	* The cache of temporary flat bonuses for each of the sp-parameters.
-	* @type {number[]}
+	* @type {[number, number, number, number, number, number, number, number, number, number]}
 	*/
 	this._j._natural._sParamsBuffPlus = [
 		0,
@@ -639,7 +639,7 @@ Game_Battler.prototype.initNaturalGrowthParameters = function() {
 	];
 	/**
 	* The cache of temporary multiplier bonuses for each of the sp-parameters.
-	* @type {number[]}
+	* @type {[number, number, number, number, number, number, number, number, number, number]}
 	*/
 	this._j._natural._sParamsBuffRate = [
 		0,
@@ -655,7 +655,7 @@ Game_Battler.prototype.initNaturalGrowthParameters = function() {
 	];
 	/**
 	* The permanent flat bonuses for each of the ex-parameters.
-	* @type {number[]}
+	* @type {[number, number, number, number, number, number, number, number, number, number]}
 	*/
 	this._j._natural._xParamsGrowthPlus = [
 		0,
@@ -671,7 +671,7 @@ Game_Battler.prototype.initNaturalGrowthParameters = function() {
 	];
 	/**
 	* The permanent multiplier bonuses for each of the ex-parameters.
-	* @type {number[]}
+	* @type {[number, number, number, number, number, number, number, number, number, number]}
 	*/
 	this._j._natural._xParamsGrowthRate = [
 		0,
@@ -687,7 +687,7 @@ Game_Battler.prototype.initNaturalGrowthParameters = function() {
 	];
 	/**
 	* The cache of temporary flat bonuses for each of the ex-parameters.
-	* @type {number[]}
+	* @type {[number, number, number, number, number, number, number, number, number, number]}
 	*/
 	this._j._natural._xParamsBuffPlus = [
 		0,
@@ -703,7 +703,7 @@ Game_Battler.prototype.initNaturalGrowthParameters = function() {
 	];
 	/**
 	* The cache of temporary multiplier bonuses for each of the ex-parameters.
-	* @type {number[]}
+	* @type {[number, number, number, number, number, number, number, number, number, number]}
 	*/
 	this._j._natural._xParamsBuffRate = [
 		0,
@@ -1080,7 +1080,7 @@ Game_Battler.prototype.setGoldPlus = function(goldPlus) {
 };
 /**
 * Gets the bonus to rewarded SDPs.
-* @returns {number|number|*}
+* @returns {number}
 */
 Game_Battler.prototype.sdpsPlus = function() {
 	return this._j._natural._sdpsPlus;
@@ -1467,126 +1467,130 @@ Game_Battler.prototype.getMaxTpBuff = function(baseParam) {
 };
 /**
 * Gets the b params growth plus.
-* @returns {*} The bParamsGrowthPlus.
+* @returns {[number, number, number, number, number, number, number, number]} The bParamsGrowthPlus.
 */
 Game_Battler.prototype.bParamsGrowthPlus = function() {
 	return this._j._natural._bParamsGrowthPlus;
 };
 /**
 * Gets the b params growth rate.
-* @returns {*} The bParamsGrowthRate.
+* @returns {[number, number, number, number, number, number, number, number]} The bParamsGrowthRate.
 */
 Game_Battler.prototype.bParamsGrowthRate = function() {
 	return this._j._natural._bParamsGrowthRate;
 };
 /**
 * Gets the b params buff plus.
-* @returns {*} The bParamsBuffPlus.
+* @returns {[number, number, number, number, number, number, number, number]} The bParamsBuffPlus.
 */
 Game_Battler.prototype.bParamsBuffPlus = function() {
 	return this._j._natural._bParamsBuffPlus;
 };
 /**
 * Sets the b params buff plus.
-* @param {*} newBParamsBuffPlus The new bParamsBuffPlus.
+* @param {[number, number, number, number, number, number, number, number]} newBParamsBuffPlus The new value.
 */
 Game_Battler.prototype.setBParamsBuffPlus = function(newBParamsBuffPlus) {
 	this._j._natural._bParamsBuffPlus = newBParamsBuffPlus;
 };
 /**
 * Gets the b params buff rate.
-* @returns {*} The bParamsBuffRate.
+* @returns {[number, number, number, number, number, number, number, number]} The bParamsBuffRate.
 */
 Game_Battler.prototype.bParamsBuffRate = function() {
 	return this._j._natural._bParamsBuffRate;
 };
 /**
 * Sets the b params buff rate.
-* @param {*} newBParamsBuffRate The new bParamsBuffRate.
+* @param {[number, number, number, number, number, number, number, number]} newBParamsBuffRate The new value.
 */
 Game_Battler.prototype.setBParamsBuffRate = function(newBParamsBuffRate) {
 	this._j._natural._bParamsBuffRate = newBParamsBuffRate;
 };
 /**
 * Gets the s params growth plus.
-* @returns {*} The sParamsGrowthPlus.
+* @returns {[number, number, number, number, number, number, number, number, number, number]} The sParamsGrowthPlus.
 */
 Game_Battler.prototype.sParamsGrowthPlus = function() {
 	return this._j._natural._sParamsGrowthPlus;
 };
 /**
 * Gets the s params growth rate.
-* @returns {*} The sParamsGrowthRate.
+* @returns {[number, number, number, number, number, number, number, number, number, number]} The sParamsGrowthRate.
 */
 Game_Battler.prototype.sParamsGrowthRate = function() {
 	return this._j._natural._sParamsGrowthRate;
 };
 /**
 * Gets the s params buff plus.
-* @returns {*} The sParamsBuffPlus.
+* @returns {[number, number, number, number, number, number, number, number, number, number]} The sParamsBuffPlus.
 */
 Game_Battler.prototype.sParamsBuffPlus = function() {
 	return this._j._natural._sParamsBuffPlus;
 };
 /**
 * Sets the s params buff plus.
-* @param {*} newSParamsBuffPlus The new sParamsBuffPlus.
+* @param {[number, number, number, number, number, number, number, number, number, number]} newSParamsBuffPlus
+* The new sParamsBuffPlus.
 */
 Game_Battler.prototype.setSParamsBuffPlus = function(newSParamsBuffPlus) {
 	this._j._natural._sParamsBuffPlus = newSParamsBuffPlus;
 };
 /**
 * Gets the s params buff rate.
-* @returns {*} The sParamsBuffRate.
+* @returns {[number, number, number, number, number, number, number, number, number, number]} The sParamsBuffRate.
 */
 Game_Battler.prototype.sParamsBuffRate = function() {
 	return this._j._natural._sParamsBuffRate;
 };
 /**
 * Sets the s params buff rate.
-* @param {*} newSParamsBuffRate The new sParamsBuffRate.
+* @param {[number, number, number, number, number, number, number, number, number, number]} newSParamsBuffRate
+* The new sParamsBuffRate.
 */
 Game_Battler.prototype.setSParamsBuffRate = function(newSParamsBuffRate) {
 	this._j._natural._sParamsBuffRate = newSParamsBuffRate;
 };
 /**
 * Gets the x params growth plus.
-* @returns {*} The xParamsGrowthPlus.
+* @returns {[number, number, number, number, number, number, number, number, number, number]} The xParamsGrowthPlus.
 */
 Game_Battler.prototype.xParamsGrowthPlus = function() {
 	return this._j._natural._xParamsGrowthPlus;
 };
 /**
 * Gets the x params growth rate.
-* @returns {*} The xParamsGrowthRate.
+* @returns {[number, number, number, number, number, number, number, number, number, number]} The xParamsGrowthRate.
 */
 Game_Battler.prototype.xParamsGrowthRate = function() {
 	return this._j._natural._xParamsGrowthRate;
 };
 /**
 * Gets the x params buff plus.
-* @returns {*} The xParamsBuffPlus.
+* @returns {[number, number, number, number, number, number, number, number, number, number]} The xParamsBuffPlus.
 */
 Game_Battler.prototype.xParamsBuffPlus = function() {
 	return this._j._natural._xParamsBuffPlus;
 };
 /**
 * Sets the x params buff plus.
-* @param {*} newXParamsBuffPlus The new xParamsBuffPlus.
+* @param {[number, number, number, number, number, number, number, number, number, number]} newXParamsBuffPlus
+* The new xParamsBuffPlus.
 */
 Game_Battler.prototype.setXParamsBuffPlus = function(newXParamsBuffPlus) {
 	this._j._natural._xParamsBuffPlus = newXParamsBuffPlus;
 };
 /**
 * Gets the x params buff rate.
-* @returns {*} The xParamsBuffRate.
+* @returns {[number, number, number, number, number, number, number, number, number, number]} The xParamsBuffRate.
 */
 Game_Battler.prototype.xParamsBuffRate = function() {
 	return this._j._natural._xParamsBuffRate;
 };
 /**
 * Sets the x params buff rate.
-* @param {*} newXParamsBuffRate The new xParamsBuffRate.
+* @param {[number, number, number, number, number, number, number, number, number, number]} newXParamsBuffRate
+* The new xParamsBuffRate.
 */
 Game_Battler.prototype.setXParamsBuffRate = function(newXParamsBuffRate) {
 	this._j._natural._xParamsBuffRate = newXParamsBuffRate;

--- a/chef-adventure/js/plugins/j/omni/ext/J-Omni-Questopedia.js
+++ b/chef-adventure/js/plugins/j/omni/ext/J-Omni-Questopedia.js
@@ -534,10 +534,10 @@ var OmniObjective = class OmniObjective {
 	*   Quest: Should be the name of the quest or some other clue to fulfill the objective.
 	* </pre>
 	* @param {number} type The type that aligns with one of {@link OmniObjective.Types}.
-	* @param {string[]=} templateDetails The details to plug into the fulfillment template- varies by what type it is.
+	* @param {(string|number)[]} templateDetails The details plugged into the template; the slots vary by type.
 	* @returns {string} The templated fulfillment for this objective.
 	*/
-	static FulfillmentTemplate(type, ...templateDetails) {
+	static FulfillmentTemplate(type, templateDetails) {
 		switch (type) {
 			case OmniObjective.Types.Indiscriminate: return templateDetails.at(0);
 			case OmniObjective.Types.Destination: return `Navigate to ${templateDetails.at(0)} at [${templateDetails.at(1)}, ${templateDetails.at(2)}].`;
@@ -1104,14 +1104,14 @@ var TrackedOmniObjective = class {
 	}
 	/**
 	* Gets the target coordinate range.
-	* @returns {*} The targetCoordinateRange.
+	* @returns {[[number, number],[number, number]]} The targetCoordinateRange.
 	*/
 	targetCoordinateRange() {
 		return this._targetCoordinateRange;
 	}
 	/**
 	* Sets the target coordinate range.
-	* @param {*} newTargetCoordinateRange The new targetCoordinateRange.
+	* @param {[[number, number],[number, number]]} newTargetCoordinateRange The new targetCoordinateRange.
 	*/
 	setTargetCoordinateRange(newTargetCoordinateRange) {
 		this._targetCoordinateRange = newTargetCoordinateRange;
@@ -1500,24 +1500,28 @@ var TrackedOmniObjective = class {
 		const enoughColor = 24;
 		const notEnoughColor = 25;
 		switch (this.type()) {
-			case OmniObjective.Types.Indiscriminate: return OmniObjective.FulfillmentTemplate(this.type(), this.indiscriminateTargetData());
+			case OmniObjective.Types.Indiscriminate: return OmniObjective.FulfillmentTemplate(this.type(), [this.indiscriminateTargetData()]);
 			case OmniObjective.Types.Destination:
 				const point1 = `${this.targetCoordinateRange().at(0)}`;
 				const point2 = `${this.targetCoordinateRange().at(1)}`;
-				return OmniObjective.FulfillmentTemplate(this.type(), $gameMap.displayName(), point1, point2);
+				return OmniObjective.FulfillmentTemplate(this.type(), [
+					$gameMap.displayName(),
+					point1,
+					point2
+				]);
 			case OmniObjective.Types.Fetch:
 				const fetchColor = this.currentItemFetchQuantity() < this.targetItemFetchQuantity() ? notEnoughColor : enoughColor;
 				const targetItemText = `${this.fetchDataSourceTextPrefix()}[${this.targetItemId()}]`;
 				const quantity = `\\C[${fetchColor}]${this.currentItemFetchQuantity()} / ${this.targetItemFetchQuantity()}\\C[0]`;
-				return OmniObjective.FulfillmentTemplate(this.type(), quantity, targetItemText);
+				return OmniObjective.FulfillmentTemplate(this.type(), [quantity, targetItemText]);
 			case OmniObjective.Types.Slay:
 				const slayColor = this.currentEnemyAmount() < this.targetEnemyAmount() ? notEnoughColor : enoughColor;
 				const targetEnemyText = `\\C[${slayColor}]${this.currentEnemyAmount()} / ${this.targetEnemyAmount()}\\C[0]`;
-				return OmniObjective.FulfillmentTemplate(this.type(), targetEnemyText, this.targetEnemyId());
+				return OmniObjective.FulfillmentTemplate(this.type(), [targetEnemyText, this.targetEnemyId()]);
 			case OmniObjective.Types.Quest:
 				const questNames = this.targetQuestKeys().map((questKey) => `'\\quest[${questKey}]'`);
 				const questNamesWithCommas = questNames.join(", ");
-				return OmniObjective.FulfillmentTemplate(this.type(), questNamesWithCommas);
+				return OmniObjective.FulfillmentTemplate(this.type(), [questNamesWithCommas]);
 		}
 	}
 	/**
@@ -2490,13 +2494,6 @@ var Window_QuestopediaCategories = class extends Window_HorzCommand {
 //#region src/plugins/omni/ext/quest/windows/Window_QuestopediaList.js
 var Window_QuestopediaList = class extends Window_Command {
 	/**
-	* Gets the quest filtering.
-	* @returns {*} The questFiltering.
-	*/
-	questFiltering() {
-		return this._questFiltering;
-	}
-	/**
 	* Constructor.
 	* @param {Rectangle} rect The rectangle that represents this window.
 	*/
@@ -2546,7 +2543,7 @@ var Window_QuestopediaList = class extends Window_Command {
 	*/
 	buildCommands() {
 		const questEntries = $gameParty.getQuestopediaEntries();
-		const filteredQuests = questEntries.filter(this.questFiltering(), this);
+		const filteredQuests = questEntries.filter(this._questFiltering, this);
 		if (filteredQuests.length === 0) return [];
 		return filteredQuests.map(this.buildCommand, this);
 	}

--- a/chef-adventure/js/plugins/j/passive/J-Passive.js
+++ b/chef-adventure/js/plugins/j/passive/J-Passive.js
@@ -903,42 +903,42 @@ Game_Battler.prototype.onStateRemoval = function(stateId) {
 };
 /**
 * Gets the state ids.
-* @returns {*} The stateIds.
+* @returns {number[]|null} The stateIds.
 */
 Game_Battler.prototype.stateIds = function() {
 	return this._j._passive._stateIds;
 };
 /**
 * Sets the state ids.
-* @param {*} newStateIds The new stateIds.
+* @param {number[]|null} newStateIds The new stateIds.
 */
 Game_Battler.prototype.setStateIds = function(newStateIds) {
 	this._j._passive._stateIds = newStateIds;
 };
 /**
 * Gets the external state sources.
-* @returns {*} The externalStateSources.
+* @returns {RPG_BaseItem[]} The externalStateSources.
 */
 Game_Battler.prototype.externalStateSources = function() {
 	return this._j._passive._externalStateSources;
 };
 /**
 * Sets the external state sources.
-* @param {*} newExternalStateSources The new externalStateSources.
+* @param {RPG_BaseItem[]} newExternalStateSources The new externalStateSources.
 */
 Game_Battler.prototype.setExternalStateSources = function(newExternalStateSources) {
 	this._j._passive._externalStateSources = newExternalStateSources;
 };
 /**
 * Gets the passive sources.
-* @returns {*} The passiveSources.
+* @returns {RPG_BaseItem[]} The passiveSources.
 */
 Game_Battler.prototype.passiveSources = function() {
 	return this._j._passive._passiveSources;
 };
 /**
 * Sets the passive sources.
-* @param {*} newPassiveSources The new passiveSources.
+* @param {RPG_BaseItem[]} newPassiveSources The new passiveSources.
 */
 Game_Battler.prototype.setPassiveSources = function(newPassiveSources) {
 	this._j._passive._passiveSources = newPassiveSources;
@@ -1155,14 +1155,14 @@ Game_Party.prototype.setStates = function(newStates) {
 };
 /**
 * Gets the cached states.
-* @returns {*} The cachedStates.
+* @returns {RPG_State[]} The cachedStates.
 */
 Game_Party.prototype.cachedStates = function() {
 	return this._j._passive._cachedStates;
 };
 /**
 * Sets the cached states.
-* @param {*} newCachedStates The new cachedStates.
+* @param {RPG_State[]} newCachedStates The new cachedStates.
 */
 Game_Party.prototype.setCachedStates = function(newCachedStates) {
 	this._j._passive._cachedStates = newCachedStates;
@@ -2810,14 +2810,15 @@ var Scene_Passive = class extends Scene_ActorFacetBase {
 	}
 	/**
 	* Gets the tab registry.
-	* @returns {*} The tabRegistry.
+	* @returns {Array<{key: string, label: string, filter: Function|null}>} The tabRegistry.
 	*/
 	static tabRegistry() {
 		return this._tabRegistry;
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_passive: {_windows: {_tabHeader: Window_Base|null, _list: Window_Base|null,
+	* _detail: Window_Base|null}, _tabIndex: number}}} The j.
 	*/
 	j() {
 		return this._j;

--- a/chef-adventure/js/plugins/j/passive/ext/J-Passive-Conditional.js
+++ b/chef-adventure/js/plugins/j/passive/ext/J-Passive-Conditional.js
@@ -2019,14 +2019,14 @@ var PassiveGateEvaluator = class {
 	/**
 	* Evaluates one gate rule kind against the battler's current map context.<br/>
 	* Discrete kinds dispatch in the switch; threshold kinds fall through to {@link #evaluateThresholdKind}.
-	* Variadic params mirror the tag tuple slots after the kind: [threshold, scope?, range?] for
+	* The params array mirrors the tag tuple slots after the kind: [threshold, scope?, range?] for
 	* resource gates; a single scalar for most other gates.
 	* @param {Game_Battler} battler The battler whose context we evaluate.
 	* @param {string} kind Rule kind from a parsed note tuple.
-	* @param {...(number|string)} params Remaining tuple slots after the kind.
+	* @param {(number|string)[]=} params Remaining tuple slots after the kind.
 	* @returns {boolean} Whether this single tuple passes right now.
 	*/
-	static evaluate(battler, kind, ...params) {
+	static evaluate(battler, kind, params = []) {
 		const [param, scope, range] = params;
 		switch (kind) {
 			case "alliesNearby": return PassiveRuleJabsAccess.nearbyAlliesExcludingSelf(battler, scope ? Number(scope) : null).length >= Number(param);
@@ -2604,10 +2604,10 @@ Game_Battler.prototype.getPassiveStackContributionFromSource = function(baseItem
 */
 Game_Battler.prototype.evaluatePassiveGateRulesForSource = function(baseItem, stateId) {
 	const sourceRules = baseItem.passiveSourceRules;
-	const passesSourceRules = sourceRules.every(([kind, ...params]) => PassiveGateEvaluator.evaluate(this, kind, ...params));
+	const passesSourceRules = sourceRules.every(([kind, ...params]) => PassiveGateEvaluator.evaluate(this, kind, params));
 	if (passesSourceRules === false) return false;
 	const stateRules = baseItem.passiveStateRules.filter(([ruleStateId]) => Number(ruleStateId) === stateId);
-	const passesStateRules = stateRules.every(([, kind, ...params]) => PassiveGateEvaluator.evaluate(this, kind, ...params));
+	const passesStateRules = stateRules.every(([, kind, ...params]) => PassiveGateEvaluator.evaluate(this, kind, params));
 	return passesStateRules;
 };
 /**
@@ -2752,126 +2752,126 @@ Game_Battler.prototype.onJabsStateInflicted = function(stateId, attacker) {
 };
 /**
 * Gets the auto rule last frame.
-* @returns {*} The autoRuleLastFrame.
+* @returns {Map<string, number>} The autoRuleLastFrame.
 */
 Game_Battler.prototype.autoRuleLastFrame = function() {
 	return this._j._passive._conditional._autoRuleLastFrame;
 };
 /**
 * Gets the auto rule tile credit.
-* @returns {*} The autoRuleTileCredit.
+* @returns {Map<string, number>} The autoRuleTileCredit.
 */
 Game_Battler.prototype.autoRuleTileCredit = function() {
 	return this._j._passive._conditional._autoRuleTileCredit;
 };
 /**
 * Gets the last moved frame.
-* @returns {*} The lastMovedFrame.
+* @returns {number} The lastMovedFrame.
 */
 Game_Battler.prototype.lastMovedFrame = function() {
 	return this._j._passive._conditional._lastMovedFrame;
 };
 /**
 * Sets the last moved frame.
-* @param {*} newLastMovedFrame The new lastMovedFrame.
+* @param {number} newLastMovedFrame The new lastMovedFrame.
 */
 Game_Battler.prototype.setLastMovedFrame = function(newLastMovedFrame) {
 	this._j._passive._conditional._lastMovedFrame = newLastMovedFrame;
 };
 /**
 * Gets the last hit frame.
-* @returns {*} The lastHitFrame.
+* @returns {number} The lastHitFrame.
 */
 Game_Battler.prototype.lastHitFrame = function() {
 	return this._j._passive._conditional._lastHitFrame;
 };
 /**
 * Sets the last hit frame.
-* @param {*} newLastHitFrame The new lastHitFrame.
+* @param {number} newLastHitFrame The new lastHitFrame.
 */
 Game_Battler.prototype.setLastHitFrame = function(newLastHitFrame) {
 	this._j._passive._conditional._lastHitFrame = newLastHitFrame;
 };
 /**
 * Gets the last attacked frame.
-* @returns {*} The lastAttackedFrame.
+* @returns {number} The lastAttackedFrame.
 */
 Game_Battler.prototype.lastAttackedFrame = function() {
 	return this._j._passive._conditional._lastAttackedFrame;
 };
 /**
 * Sets the last attacked frame.
-* @param {*} newLastAttackedFrame The new lastAttackedFrame.
+* @param {number} newLastAttackedFrame The new lastAttackedFrame.
 */
 Game_Battler.prototype.setLastAttackedFrame = function(newLastAttackedFrame) {
 	this._j._passive._conditional._lastAttackedFrame = newLastAttackedFrame;
 };
 /**
 * Gets the last hp heal frame.
-* @returns {*} The lastHpHealFrame.
+* @returns {number} The lastHpHealFrame.
 */
 Game_Battler.prototype.lastHpHealFrame = function() {
 	return this._j._passive._conditional._lastHpHealFrame;
 };
 /**
 * Sets the last hp heal frame.
-* @param {*} newLastHpHealFrame The new lastHpHealFrame.
+* @param {number} newLastHpHealFrame The new lastHpHealFrame.
 */
 Game_Battler.prototype.setLastHpHealFrame = function(newLastHpHealFrame) {
 	this._j._passive._conditional._lastHpHealFrame = newLastHpHealFrame;
 };
 /**
 * Gets the last mp heal frame.
-* @returns {*} The lastMpHealFrame.
+* @returns {number} The lastMpHealFrame.
 */
 Game_Battler.prototype.lastMpHealFrame = function() {
 	return this._j._passive._conditional._lastMpHealFrame;
 };
 /**
 * Sets the last mp heal frame.
-* @param {*} newLastMpHealFrame The new lastMpHealFrame.
+* @param {number} newLastMpHealFrame The new lastMpHealFrame.
 */
 Game_Battler.prototype.setLastMpHealFrame = function(newLastMpHealFrame) {
 	this._j._passive._conditional._lastMpHealFrame = newLastMpHealFrame;
 };
 /**
 * Gets the last tp heal frame.
-* @returns {*} The lastTpHealFrame.
+* @returns {number} The lastTpHealFrame.
 */
 Game_Battler.prototype.lastTpHealFrame = function() {
 	return this._j._passive._conditional._lastTpHealFrame;
 };
 /**
 * Sets the last tp heal frame.
-* @param {*} newLastTpHealFrame The new lastTpHealFrame.
+* @param {number} newLastTpHealFrame The new lastTpHealFrame.
 */
 Game_Battler.prototype.setLastTpHealFrame = function(newLastTpHealFrame) {
 	this._j._passive._conditional._lastTpHealFrame = newLastTpHealFrame;
 };
 /**
 * Gets the pending fingerprint.
-* @returns {*} The pendingFingerprint.
+* @returns {string|null} The pendingFingerprint.
 */
 Game_Battler.prototype.pendingFingerprint = function() {
 	return this._j._passive._conditional._pendingFingerprint;
 };
 /**
 * Sets the pending fingerprint.
-* @param {*} newPendingFingerprint The new pendingFingerprint.
+* @param {string|null} newPendingFingerprint The new pendingFingerprint.
 */
 Game_Battler.prototype.setPendingFingerprint = function(newPendingFingerprint) {
 	this._j._passive._conditional._pendingFingerprint = newPendingFingerprint;
 };
 /**
 * Gets the collection fingerprint.
-* @returns {*} The collectionFingerprint.
+* @returns {string} The collectionFingerprint.
 */
 Game_Battler.prototype.collectionFingerprint = function() {
 	return this._j._passive._conditional._collectionFingerprint;
 };
 /**
 * Sets the collection fingerprint.
-* @param {*} newCollectionFingerprint The new collectionFingerprint.
+* @param {string} newCollectionFingerprint The new collectionFingerprint.
 */
 Game_Battler.prototype.setCollectionFingerprint = function(newCollectionFingerprint) {
 	this._j._passive._conditional._collectionFingerprint = newCollectionFingerprint;

--- a/chef-adventure/js/plugins/j/pixel/J-Pixelistics.js
+++ b/chef-adventure/js/plugins/j/pixel/J-Pixelistics.js
@@ -290,14 +290,14 @@ var PixelDebugSampler = class PixelDebugSampler {
 var PIXEL_CollisionManager = class {
 	/**
 	* Gets the table.
-	* @returns {*} The table.
+	* @returns {number[]} The table.
 	*/
 	static table() {
 		return this._table;
 	}
 	/**
 	* Sets the table.
-	* @param {*} newTable The new table.
+	* @param {number[]} newTable The new table.
 	*/
 	static setTable(newTable) {
 		this._table = newTable;
@@ -2902,21 +2902,21 @@ Game_Player.prototype.setLastOccupiedTileY = function(newLastOccupiedTileY) {
 var Sprite_PixelCollisionOverlay = class extends Sprite {
 	/**
 	* Gets the show grid lines.
-	* @returns {*} The showGridLines.
+	* @returns {boolean} The showGridLines.
 	*/
 	isShowGridLines() {
 		return this._showGridLines;
 	}
 	/**
 	* Gets the throttle.
-	* @returns {*} The throttle.
+	* @returns {number} The throttle.
 	*/
 	throttle() {
 		return this._throttle;
 	}
 	/**
 	* Sets the throttle.
-	* @param {*} newThrottle The new throttle.
+	* @param {number} newThrottle The new throttle.
 	*/
 	setThrottle(newThrottle) {
 		this._throttle = newThrottle;
@@ -2979,11 +2979,10 @@ var Sprite_PixelCollisionOverlay = class extends Sprite {
 	}
 	/**
 	* Constructor.
-	* @param {...*} args Forwarded to {@link #initialize}.
 	*/
-	constructor(...args) {
+	constructor() {
 		super();
-		this.initialize(...args);
+		this.initialize();
 	}
 	/**
 	* Initializes the overlay's bitmap and configuration.
@@ -3276,14 +3275,14 @@ Spriteset_Map.prototype.update = function() {
 };
 /**
 * Gets the pixel overlay visible.
-* @returns {*} The pixelOverlayVisible.
+* @returns {boolean} The pixelOverlayVisible.
 */
 Spriteset_Map.prototype.pixelOverlayVisible = function() {
 	return this._pixelOverlayVisible;
 };
 /**
 * Sets the pixel overlay visible.
-* @param {*} newPixelOverlayVisible The new pixelOverlayVisible.
+* @param {boolean} newPixelOverlayVisible The new pixelOverlayVisible.
 */
 Spriteset_Map.prototype.setPixelOverlayVisible = function(newPixelOverlayVisible) {
 	this._pixelOverlayVisible = newPixelOverlayVisible;

--- a/chef-adventure/js/plugins/j/pixel/ext/J-Pixel-ABS.js
+++ b/chef-adventure/js/plugins/j/pixel/ext/J-Pixel-ABS.js
@@ -1467,28 +1467,28 @@ JABS_Battler.prototype.canDirectionalDodgeStepPass = function(character, directi
 };
 /**
 * Gets the pixel idle dest.
-* @returns {*} The pixelIdleDest.
+* @returns {{x: number, y: number}|null} The pixelIdleDest.
 */
 JABS_Battler.prototype.pixelIdleDest = function() {
 	return this._pixelIdleDest;
 };
 /**
 * Sets the pixel idle dest.
-* @param {*} newPixelIdleDest The new pixelIdleDest.
+* @param {{x: number, y: number}|null} newPixelIdleDest The new pixelIdleDest.
 */
 JABS_Battler.prototype.setPixelIdleDest = function(newPixelIdleDest) {
 	this._pixelIdleDest = newPixelIdleDest;
 };
 /**
 * Gets the pixel idle wait.
-* @returns {*} The pixelIdleWait.
+* @returns {number} The pixelIdleWait.
 */
 JABS_Battler.prototype.pixelIdleWait = function() {
 	return this._pixelIdleWait;
 };
 /**
 * Sets the pixel idle wait.
-* @param {*} newPixelIdleWait The new pixelIdleWait.
+* @param {number} newPixelIdleWait The new pixelIdleWait.
 */
 JABS_Battler.prototype.setPixelIdleWait = function(newPixelIdleWait) {
 	this._pixelIdleWait = newPixelIdleWait;
@@ -1715,28 +1715,28 @@ Spriteset_Map.prototype.getPixelAbsRevealHitboxStyle = function() {
 };
 /**
 * Gets the hitbox reveal layer.
-* @returns {*} The hitboxRevealLayer.
+* @returns {Sprite} The hitboxRevealLayer.
 */
 Spriteset_Map.prototype.hitboxRevealLayer = function() {
 	return this._j._pixel._abs._hitboxRevealLayer;
 };
 /**
 * Sets the hitbox reveal layer.
-* @param {*} newHitboxRevealLayer The new hitboxRevealLayer.
+* @param {Sprite} newHitboxRevealLayer The new hitboxRevealLayer.
 */
 Spriteset_Map.prototype.setHitboxRevealLayer = function(newHitboxRevealLayer) {
 	this._j._pixel._abs._hitboxRevealLayer = newHitboxRevealLayer;
 };
 /**
 * Gets the hitbox reveal sprites.
-* @returns {*} The hitboxRevealSprites.
+* @returns {Record<string, Sprite>} The hitboxRevealSprites.
 */
 Spriteset_Map.prototype.hitboxRevealSprites = function() {
 	return this._j._pixel._abs._hitboxRevealSprites;
 };
 /**
 * Sets the hitbox reveal sprites.
-* @param {*} newHitboxRevealSprites The new hitboxRevealSprites.
+* @param {Record<string, Sprite>} newHitboxRevealSprites The new hitboxRevealSprites.
 */
 Spriteset_Map.prototype.setHitboxRevealSprites = function(newHitboxRevealSprites) {
 	this._j._pixel._abs._hitboxRevealSprites = newHitboxRevealSprites;

--- a/chef-adventure/js/plugins/j/popups/J-Popups.js
+++ b/chef-adventure/js/plugins/j/popups/J-Popups.js
@@ -1038,7 +1038,10 @@ var PopupNumericDisplay = class {
 var Sprite_MapDamage = class extends Sprite_Damage {
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_popups: {_mapAccumulatePhase: boolean, _mergePulseFrameIndex: number,
+	* _mergePulseTotalFrames: number, _mergePulseBaseFrames: number, _mergePulseHoldFrames: number,
+	* _mergePulsePeakScale: number, _mergePulseFlashMaxAlpha: number,
+	* _mergePulseFlashAlpha: number}}} The j.
 	*/
 	j() {
 		return this._j;
@@ -1059,11 +1062,10 @@ var Sprite_MapDamage = class extends Sprite_Damage {
 	}
 	/**
 	* Constructor.
-	* @param {...*} args Forwarded to {@link #initialize}.
 	*/
-	constructor(...args) {
+	constructor() {
 		super();
-		this.initialize(...args);
+		this.initialize();
 	}
 	/**
 	* Runs after {@link Sprite_Damage.prototype.initialize}.
@@ -1970,7 +1972,7 @@ Sprite_Damage.prototype.setIsCritical = function(newIsCritical) {
 };
 /**
 * Gets the text accent.
-* @returns {*} The textAccent.
+* @returns {string|null} The textAccent.
 */
 Sprite_Damage.prototype.textAccent = function() {
 	return this._j._popups._textAccent;
@@ -2185,28 +2187,28 @@ Sprite_Character.prototype.updateNonDamagePopLocation = function(nonDamageSprite
 };
 /**
 * Gets the damage pop sprites.
-* @returns {*} The damagePopSprites.
+* @returns {Sprite_Damage[]} The damagePopSprites.
 */
 Sprite_Character.prototype.damagePopSprites = function() {
 	return this._j._popups._damagePopSprites;
 };
 /**
 * Sets the damage pop sprites.
-* @param {*} newDamagePopSprites The new damagePopSprites.
+* @param {Sprite_Damage[]} newDamagePopSprites The new damagePopSprites.
 */
 Sprite_Character.prototype.setDamagePopSprites = function(newDamagePopSprites) {
 	this._j._popups._damagePopSprites = newDamagePopSprites;
 };
 /**
 * Gets the non damage pop sprites.
-* @returns {*} The nonDamagePopSprites.
+* @returns {Sprite_Damage[]} The nonDamagePopSprites.
 */
 Sprite_Character.prototype.nonDamagePopSprites = function() {
 	return this._j._popups._nonDamagePopSprites;
 };
 /**
 * Sets the non damage pop sprites.
-* @param {*} newNonDamagePopSprites The new nonDamagePopSprites.
+* @param {Sprite_Damage[]} newNonDamagePopSprites The new nonDamagePopSprites.
 */
 Sprite_Character.prototype.setNonDamagePopSprites = function(newNonDamagePopSprites) {
 	this._j._popups._nonDamagePopSprites = newNonDamagePopSprites;
@@ -2292,14 +2294,14 @@ Game_Character.prototype.clearPendingTextPops = function() {
 };
 /**
 * Gets the text pop request.
-* @returns {*} The textPopRequest.
+* @returns {boolean} The textPopRequest.
 */
 Game_Character.prototype.isTextPopRequest = function() {
 	return this._j._textPopRequest;
 };
 /**
 * Sets the text pop request.
-* @param {*} newTextPopRequest The new textPopRequest.
+* @param {boolean} newTextPopRequest The new textPopRequest.
 */
 Game_Character.prototype.setTextPopRequest = function(newTextPopRequest) {
 	this._j._textPopRequest = newTextPopRequest;

--- a/chef-adventure/js/plugins/j/prof/J-Proficiency.js
+++ b/chef-adventure/js/plugins/j/prof/J-Proficiency.js
@@ -777,14 +777,14 @@ Object.defineProperty(Game_Actor.prototype, "prof", {
 });
 /**
 * Gets the bonus skill proficiency gains.
-* @returns {*} The bonusSkillProficiencyGains.
+* @returns {number} The bonusSkillProficiencyGains.
 */
 Game_Actor.prototype.bonusSkillProficiencyGains = function() {
 	return this._j._proficiency._bonusSkillProficiencyGains;
 };
 /**
 * Sets the bonus skill proficiency gains.
-* @param {*} newBonusSkillProficiencyGains The new bonusSkillProficiencyGains.
+* @param {number} newBonusSkillProficiencyGains The new bonusSkillProficiencyGains.
 */
 Game_Actor.prototype.setBonusSkillProficiencyGains = function(newBonusSkillProficiencyGains) {
 	this._j._proficiency._bonusSkillProficiencyGains = newBonusSkillProficiencyGains;

--- a/chef-adventure/js/plugins/j/resources/ext/J-Resources-ABS.js
+++ b/chef-adventure/js/plugins/j/resources/ext/J-Resources-ABS.js
@@ -434,21 +434,21 @@ IconManager.tst = function() {
 var HealEventManager = class {
 	/**
 	* Gets the current depth.
-	* @returns {*} The currentDepth.
+	* @returns {number} The currentDepth.
 	*/
 	static currentDepth() {
 		return this._currentDepth;
 	}
 	/**
 	* Sets the current depth.
-	* @param {*} newCurrentDepth The new currentDepth.
+	* @param {number} newCurrentDepth The new currentDepth.
 	*/
 	static setCurrentDepth(newCurrentDepth) {
 		this._currentDepth = newCurrentDepth;
 	}
 	/**
 	* Gets the self blocked tags.
-	* @returns {*} The selfBlockedTags.
+	* @returns {Set<string>} The selfBlockedTags.
 	*/
 	static selfBlockedTags() {
 		return this._selfBlockedTags;

--- a/chef-adventure/js/plugins/j/sdp/J-SDP.js
+++ b/chef-adventure/js/plugins/j/sdp/J-SDP.js
@@ -3347,7 +3347,7 @@ Game_System.prototype.disableForcedSdpDrops = function() {
 };
 /**
 * Determines whether or not the DEBUG functionality of forced-panel-dropping is active.
-* @returns {boolean|*|boolean}
+* @returns {boolean}
 */
 Game_System.prototype.shouldForceDropSdp = function() {
 	return this._j._sdp._forceDropPanels;
@@ -5032,7 +5032,9 @@ var Scene_SDP = class extends Scene_ActorFacetBase {
 	}
 	/**
 	* Gets the j.
-	* @returns {*} The j.
+	* @returns {{_sdp: {_windows: {_sdpList: Window_Base|null, _sdpHeader: Window_Base|null,
+	* _sdpParameterList: Window_Base|null, _sdpRewardList: Window_Base|null,
+	* _sdpMastery: Window_Base|null, _sdpCart: Window_Base|null}}}} The j.
 	*/
 	j() {
 		return this._j;

--- a/chef-adventure/js/plugins/j/sks/J-SkillSlots.js
+++ b/chef-adventure/js/plugins/j/sks/J-SkillSlots.js
@@ -816,7 +816,7 @@ var Window_SkillEquipRibbon = class extends Window_ActorRibbon {
 	}
 	/**
 	* Gets the actor.
-	* @returns {*} The actor.
+	* @returns {Game_Actor} The actor.
 	*/
 	actor() {
 		return this._actor;

--- a/chef-adventure/js/plugins/j/time/J-TIME.js
+++ b/chef-adventure/js/plugins/j/time/J-TIME.js
@@ -1520,7 +1520,7 @@ var Game_Time = class Game_Time {
 	}
 	/**
 	* Gets the visible.
-	* @returns {*} The visible.
+	* @returns {boolean} The visible.
 	*/
 	isVisible() {
 		return this._visible;
@@ -1548,28 +1548,28 @@ var Game_Time = class Game_Time {
 	}
 	/**
 	* Gets the hours.
-	* @returns {*} The hours.
+	* @returns {number} The hours.
 	*/
 	hours() {
 		return this._hours;
 	}
 	/**
 	* Sets the hours.
-	* @param {*} newHours The new hours.
+	* @param {number} newHours The new hours.
 	*/
 	setHours(newHours) {
 		this._hours = newHours;
 	}
 	/**
 	* Gets the months.
-	* @returns {*} The months.
+	* @returns {number} The months.
 	*/
 	months() {
 		return this._months;
 	}
 	/**
 	* Sets the months.
-	* @param {*} newMonths The new months.
+	* @param {number} newMonths The new months.
 	*/
 	setMonths(newMonths) {
 		this._months = newMonths;
@@ -1604,63 +1604,63 @@ var Game_Time = class Game_Time {
 	}
 	/**
 	* Gets the days.
-	* @returns {*} The days.
+	* @returns {number} The days.
 	*/
 	days() {
 		return this._days;
 	}
 	/**
 	* Sets the days.
-	* @param {*} newDays The new days.
+	* @param {number} newDays The new days.
 	*/
 	setDays(newDays) {
 		this._days = newDays;
 	}
 	/**
 	* Gets the years.
-	* @returns {*} The years.
+	* @returns {number} The years.
 	*/
 	years() {
 		return this._years;
 	}
 	/**
 	* Sets the years.
-	* @param {*} newYears The new years.
+	* @param {number} newYears The new years.
 	*/
 	setYears(newYears) {
 		this._years = newYears;
 	}
 	/**
 	* Gets the minutes per tick.
-	* @returns {*} The minutesPerTick.
+	* @returns {number} The minutesPerTick.
 	*/
 	minutesPerTick() {
 		return this._minutesPerTick;
 	}
 	/**
 	* Gets the hours per tick.
-	* @returns {*} The hoursPerTick.
+	* @returns {number} The hoursPerTick.
 	*/
 	hoursPerTick() {
 		return this._hoursPerTick;
 	}
 	/**
 	* Gets the days per tick.
-	* @returns {*} The daysPerTick.
+	* @returns {number} The daysPerTick.
 	*/
 	daysPerTick() {
 		return this._daysPerTick;
 	}
 	/**
 	* Gets the months per tick.
-	* @returns {*} The monthsPerTick.
+	* @returns {number} The monthsPerTick.
 	*/
 	monthsPerTick() {
 		return this._monthsPerTick;
 	}
 	/**
 	* Gets the years per tick.
-	* @returns {*} The yearsPerTick.
+	* @returns {number} The yearsPerTick.
 	*/
 	yearsPerTick() {
 		return this._yearsPerTick;


### PR DESCRIPTION
Mirrors the rebuilt plugins from je-can-code/rmmz-plugins#69. No game data, maps, or database
entries are touched — this is `copy:to-all` output only.

What the rebuild carries:

- every wildcard JSDoc type replaced with the real one, read from the source rather than guessed
- nine constructors and four variadic APIs given explicit named parameters, including
  `JCache.get(weakKeys, stableKey, computeFn)` and `invalidate(prefix = [])`
- the spurious `Window_QuestopediaList.questFiltering()` getter removed — it wrapped a method, not
  a field, and existed only because a verify gate could not tell the two apart

No plugin versions changed, so `plugins.js` needs no edits and load order is unaffected.

Verified upstream by `bun run hotfix`: eleven source gates, 78 plugins, 776 test files,
12,930 tests passing.

**Merge after rmmz-plugins#69**, so the built output here always has a source commit behind it.
