### PR TITLE
Mirror the menu status cards and private-member gate (rmmz-plugins#72)

### DIFF
--- a/chef-adventure/js/plugins/j/abs/ext/J-ABS-Boss.js
+++ b/chef-adventure/js/plugins/j/abs/ext/J-ABS-Boss.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.0.0 ABS-BOSS] Data-driven boss encounters for J-ABS.
+ * [v1.0.1 ABS-BOSS] Data-driven boss encounters for J-ABS.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -120,6 +120,11 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 1.0.1
+ *    The plugin metadata class no longer declares private members. Its base
+ *    constructor reaches postInitialize before a derived class installs its
+ *    own, so anything private was being touched on an object that did not yet
+ *    have it, which threw during boot.
  * - 1.0.0
  *    The initial release.
  * ============================================================================
@@ -734,19 +739,24 @@ var J_BossPluginMetadata = class extends PluginMetadata {
 	*/
 	initializeBossEncounters() {
 		const { bosses } = J.ABS.Metadata.ExternalConfig;
-		const encounters = bosses.map((rawEncounter) => this.#parseEncounter(rawEncounter));
+		const encounters = bosses.map((rawEncounter) => this.parseEncounter(rawEncounter));
 		JabsBossManager.registerEncounters(encounters);
 	}
 	/**
 	* Builds one encounter out of its raw configuration.
+	*
+	* None of the parse helpers below may be `#private`. The whole chain runs out of
+	* {@link PluginMetadata}'s constructor by way of `postInitialize`, and a derived class installs its
+	* private members only after `super()` returns- so a private helper does not exist yet at the moment
+	* this runs, and touching one throws before the game finishes booting.
 	* @param {any} rawEncounter The unparsed encounter from configuration.
 	* @returns {JabsBossEncounter}
 	*/
-	#parseEncounter(rawEncounter) {
-		const participants = rawEncounter.participants.map((raw) => this.#parseParticipant(raw));
+	parseEncounter(rawEncounter) {
+		const participants = rawEncounter.participants.map((raw) => this.parseParticipant(raw));
 		const aiControl = rawEncounter.aiControl ?? J.ABS.EXT.BOSS.AiControl.Shared;
 		const rawRoutines = rawEncounter.routines ?? [];
-		const routines = rawRoutines.map((raw) => this.#parseRoutine(raw));
+		const routines = rawRoutines.map((raw) => this.parseRoutine(raw));
 		return new JabsBossEncounter(rawEncounter.key, rawEncounter.map, participants, aiControl, routines);
 	}
 	/**
@@ -754,7 +764,7 @@ var J_BossPluginMetadata = class extends PluginMetadata {
 	* @param {any} rawParticipant The unparsed participant from configuration.
 	* @returns {JabsBossParticipant}
 	*/
-	#parseParticipant(rawParticipant) {
+	parseParticipant(rawParticipant) {
 		const { key, eventId, enemyId, expect } = rawParticipant;
 		return new JabsBossParticipant(key, eventId, enemyId, expect);
 	}
@@ -763,9 +773,9 @@ var J_BossPluginMetadata = class extends PluginMetadata {
 	* @param {any} rawRoutine The unparsed routine from configuration.
 	* @returns {JabsBossRoutine}
 	*/
-	#parseRoutine(rawRoutine) {
+	parseRoutine(rawRoutine) {
 		const cadenceFrames = Math.round(rawRoutine.cadence * FRAMES_PER_SECOND);
-		const steps = rawRoutine.steps.map((raw) => this.#parseStep(raw));
+		const steps = rawRoutine.steps.map((raw) => this.parseStep(raw));
 		return new JabsBossRoutine(rawRoutine.key, cadenceFrames, steps);
 	}
 	/**
@@ -773,7 +783,7 @@ var J_BossPluginMetadata = class extends PluginMetadata {
 	* @param {any} rawStep The unparsed step from configuration.
 	* @returns {JabsBossStep}
 	*/
-	#parseStep(rawStep) {
+	parseStep(rawStep) {
 		const { verb, skill, expect } = rawStep;
 		const cast = rawStep.cast !== false;
 		return new JabsBossStep(verb, skill, expect, cast);
@@ -805,7 +815,7 @@ J.ABS.EXT.BOSS = {};
 /**
 * The metadata associated with this plugin.
 */
-J.ABS.EXT.BOSS.Metadata = new J_BossPluginMetadata("J-ABS-Boss", "1.0.0");
+J.ABS.EXT.BOSS.Metadata = new J_BossPluginMetadata("J-ABS-Boss", "1.0.1");
 /**
 * A collection of all aliased methods for this plugin.
 */

--- a/chef-adventure/js/plugins/j/cms/core/J-CMS.js
+++ b/chef-adventure/js/plugins/j/cms/core/J-CMS.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.0.0 CMS] A redesign of the main menu.
+ * [v1.1.0 CMS] A redesign of the main menu.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -28,6 +28,36 @@
  * This plugin has no notetags of its own- it is purely a scene/window
  * redesign of the native main menu.
  * ============================================================================
+ * CHANGELOG:
+ * - 1.1.0
+ *    Each party member's cell is now a character card rather than a data row.
+ *    It is headed by their name with their class beneath it, carries their map
+ *    sprite beside their portrait, and is banded into sections by rules.
+ *    Level and remaining experience share a row, since a level means little
+ *    without knowing how close the next one is.
+ *    Resources are drawn as segmented gauges spanning the cell, marked by icon
+ *    rather than by abbreviation and trailed by their current and maximum
+ *    values.
+ *    Afflicting states are listed by icon, and an actor suffering none says so
+ *    rather than leaving the row blank.
+ *    Every equipment slot is listed, with empty ones named and dimmed rather
+ *    than omitted, so the block keeps its shape as gear comes and goes.
+ *    A drawExtensionData hook sits alongside level and experience for other
+ *    plugins to contribute to; it returns the position it finished at, so any
+ *    number of them may each claim a row without knowing about one another.
+ *    The party display no longer tints each cell behind its contents. That
+ *    tint marks which row a cursor is on, and nothing selects a party member
+ *    here- it advertised an interaction that does not exist.
+ *    Fixed the party display overrunning the currency strip by the height of
+ *    the control legend. It was measuring its own floor from the bottom of the
+ *    screen by the strip's height rather than stopping at the strip's position,
+ *    and the sixty pixels it overran were hidden underneath the very window
+ *    that caused it.
+ *    Command help text no longer refers to "this character", which pointed at
+ *    a referent the menu never identifies.
+ * - 1.0.0
+ *    The initial release.
+ * ============================================================================
  *
  * @param parentConfig
  * @text COMMAND DESCRIPTIONS
@@ -44,21 +74,21 @@
  * @type multiline_string
  * @text Abilities
  * @desc Describes the abilities command in the menu's help window.
- * @default Review every ability this character knows.
+ * @default Review the abilities you've learned.
  *
  * @param help-equip
  * @parent parentConfig
  * @type multiline_string
  * @text Equipment
  * @desc Describes the equipment command in the menu's help window.
- * @default Change the weapons and armor this character has equipped.
+ * @default Change the weapons and armor you have equipped.
  *
  * @param help-status
  * @parent parentConfig
  * @type multiline_string
  * @text Status
  * @desc Describes the status command in the menu's help window.
- * @default Inspect this character's parameters in detail.
+ * @default Inspect your parameters in detail.
  *
  * @param help-options
  * @parent parentConfig
@@ -161,7 +191,7 @@ J.CMS = {};
 /**
 * The `metadata` associated with this plugin, such as version.
 */
-J.CMS.Metadata = new J_CmsMain_PluginMetadata("J-CMS", "1.0.0");
+J.CMS.Metadata = new J_CmsMain_PluginMetadata("J-CMS", "1.1.0");
 /**
 * The plugin umbrella that governs all extensions of this plugin.
 */
@@ -313,6 +343,157 @@ var MenuCommandBroadcaster = class {
 	*/
 	windows() {
 		return this.#windows;
+	}
+};
+
+//#endregion
+//#region src/plugins/cms/core/helpers/MenuStatusCatalog.js
+/**
+* The contents of a single actor's cell in the main menu's party display, decided but not drawn.
+*
+* What belongs in a cell is a policy question that keeps changing as the game grows; how a line of
+* text lands on a bitmap is not. Separating the two means the policy can be exercised directly-
+* asking what an actor with an empty weapon slot reads as should not require standing up a window,
+* a bitmap, and a font metric to find out.
+*
+* Every method here is static and takes the actor rather than the window, because nothing in this
+* class measures or draws. These are answers about a battler, not about a rectangle.
+*/
+var MenuStatusCatalog = class MenuStatusCatalog {
+	/**
+	* Stands in for the item name of a slot holding nothing.
+	* @type {string}
+	*/
+	static EMPTY_SLOT_TEXT = "nothing equipped";
+	/**
+	* Stands in for the experience readout of an actor with no further levels to earn.
+	* @type {string}
+	*/
+	static MAX_LEVEL_TEXT = "MAX";
+	/**
+	* Separates the level from the distance to the next one.
+	* @type {string}
+	*/
+	static LEVEL_DIVIDER = "-";
+	/**
+	* Stands in for the state icons of an actor suffering nothing at all.
+	*
+	* An empty row would read as "this section has not loaded" rather than as good news. Saying it
+	* outright costs one line and removes the ambiguity.
+	* @type {string}
+	*/
+	static UNAFFLICTED_TEXT = "Unafflicted";
+	/**
+	* The level readout for an actor.
+	*
+	* The bare number, with no word naming it. The icon drawn beside it says what it is, and it says
+	* so in the same visual language every other measure in this menu uses- a player who has learned
+	* one of these icons has learned all of them, which is worth more than a word repeated on every
+	* row.
+	* @param {Game_Actor} actor The actor whose level is being described.
+	* @returns {string}
+	*/
+	static levelValue(actor) {
+		return `${actor.level}`;
+	}
+	/**
+	* The resources worth showing for an actor, in the order they are drawn.
+	*
+	* Each row carries the numbers and the fill rate, but names its resource with a key rather than a
+	* color- what blue means is a question for whatever draws the row, and answering it here would
+	* drag ColorManager into a class that otherwise never touches the screen.
+	*
+	* Tech is included only when the database says to display it, which is the same condition the
+	* engine's own gauge placement honors.
+	* @param {Game_Actor} actor The actor whose resources are being catalogued.
+	* @returns {{key: string, label: string, current: number, max: number, rate: number}[]}
+	*/
+	static resourceRows(actor) {
+		const rows = [MenuStatusCatalog.buildResourceRow("hp", TextManager.hpA, actor.hp, actor.mhp), MenuStatusCatalog.buildResourceRow("mp", TextManager.mpA, actor.mp, actor.mmp)];
+		if ($dataSystem.optDisplayTp) {
+			rows.push(MenuStatusCatalog.buildResourceRow("tp", TextManager.tpA, actor.tp, actor.maxTp()));
+		}
+		return rows;
+	}
+	/**
+	* Builds a single resource row, including the fill rate its gauge needs.
+	*
+	* A resource with no capacity reads as empty rather than as a division by zero. That is a real
+	* state rather than a defensive one- an actor with no magic at all has an mmp of zero, and the row
+	* still has to render something.
+	* @param {string} key Which resource this is, being one of 'hp', 'mp', or 'tp'.
+	* @param {string} label The abbreviation the database names this resource with.
+	* @param {number} current How much of the resource the actor currently holds.
+	* @param {number} max How much of the resource the actor can hold.
+	* @returns {{key: string, label: string, current: number, max: number, rate: number}}
+	*/
+	static buildResourceRow(key, label, current, max) {
+		return {
+			key,
+			label,
+			current,
+			max,
+			rate: max === 0 ? 0 : current / max
+		};
+	}
+	/**
+	* The icons of every state currently afflicting an actor.
+	*
+	* States without an icon are dropped rather than drawn as a gap. A state that chose not to show
+	* itself in the status bar has no business claiming space in the menu either.
+	* @param {Game_Actor} actor The actor whose afflictions are being catalogued.
+	* @returns {number[]}
+	*/
+	static stateIcons(actor) {
+		return actor.states().map((state) => state.iconIndex).filter((iconIndex) => iconIndex > 0);
+	}
+	/**
+	* Builds one row per equipment slot the actor wears, in the order they are worn.
+	*
+	* Empty slots are kept rather than dropped. A missing weapon is itself information, and dropping
+	* the row would leave the player counting slots to work out which one they forgot to fill- while
+	* also making the block shift height every time a piece of gear comes or goes.
+	* @param {Game_Actor} actor The actor whose loadout is being catalogued.
+	* @returns {{item: RPG_EquipItem, slotName: string, isEquipped: boolean}[]}
+	*/
+	static equipmentRows(actor) {
+		const slotTypeIds = actor.equipSlots();
+		const equips = actor.equips();
+		return slotTypeIds.map((slotTypeId, index) => {
+			const item = equips.at(index);
+			return MenuStatusCatalog.buildEquipmentRow(slotTypeId, item);
+		});
+	}
+	/**
+	* Builds a single equipment row from a slot type and whatever currently occupies it.
+	*
+	* The slot name is resolved here rather than at draw time so that an empty row still knows what
+	* it stands for. A filled row identifies itself by the item's own icon and name, but an empty one
+	* has neither and would otherwise be an anonymous blank line.
+	* @param {number} slotTypeId The 1-based equip type this slot accepts.
+	* @param {RPG_EquipItem} item The equipment in the slot, or null while the slot is empty.
+	* @returns {{item: RPG_EquipItem, slotName: string, isEquipped: boolean}}
+	*/
+	static buildEquipmentRow(slotTypeId, item) {
+		return {
+			item,
+			slotName: TextManager.equipType(slotTypeId),
+			isEquipped: item !== null
+		};
+	}
+	/**
+	* The experience readout for an actor, phrased as the distance still to travel.
+	*
+	* Deliberately derived from the actor rather than stated as a constant. The size of a level is a
+	* plugin parameter of J-Level-Flat, so a readout naming today's interval would quietly begin
+	* lying the moment that parameter changed- and nothing would report the discrepancy.
+	* @param {Game_Actor} actor The actor whose progress is being described.
+	* @returns {string}
+	*/
+	static experienceLabel(actor) {
+		if (actor.isMaxLevel()) return MenuStatusCatalog.MAX_LEVEL_TEXT;
+		const remaining = actor.nextLevelExp() - actor.currentExp();
+		return `${remaining} to next level`;
 	}
 };
 
@@ -1159,39 +1340,467 @@ Window_MenuStatus.prototype.itemHeight = function() {
 	return this.innerHeight;
 };
 /**
-* Overwrites {@link #drawItemImage}.<br/>
-* Draws the actor's face at the top of their column.
+* Overwrites {@link Window_Selectable.drawItemBackground}.<br/>
+* Draws no backing behind a member's cell.
 *
-* This is the only place in the game a full-size portrait appears. Concentrating it here is what
-* permits every other actor-scoped scene to carry a compact ribbon instead of re-rendering the same
-* artwork in a layout that has better uses for the space.
+* The tinted rectangle behind a row exists to show which row the cursor is on. Nothing selects a
+* party member here- the two command columns own the cursor and this window is read-only- so the
+* tint marks nothing, and reads as a panel the player ought to be able to interact with. The engine
+* does the same for its own read-only {@link Window_StatusParams}.
+* @param {number} _index The index of the party member whose cell would have been backed.
+*/
+Window_MenuStatus.prototype.drawItemBackground = function(_index) {};
+/**
+* Overwrites {@link #drawItemImage}.<br/>
+* Draws the actor's name across the top, then their face and map sprite beneath it.
+*
+* The name leads because a cell without a header reads as a data row rather than as a person- the
+* player has to infer whose column this is from the artwork. Naming it first turns the column into a
+* card, which is the difference between a menu and a screen worth looking at.
+*
+* Two graphics rather than one because they answer different questions. The face is who this person
+* is in a conversation; the map sprite is who the player has been looking at for the last several
+* hours of play, and in an action game that is the stronger identification of the two.
 * @param {number} index The index of the party member being rendered.
 */
 Window_MenuStatus.prototype.drawItemImage = function(index) {
 	const actor = this.actor(index);
 	const rect = this.itemRect(index);
-	const faceX = rect.x + Math.floor((rect.width - ImageManager.faceWidth) / 2);
-	this.drawActorFace(actor, faceX, rect.y, ImageManager.faceWidth, ImageManager.faceHeight);
+	this.drawActorNameHeader(actor, rect);
+	this.drawActorClassSubtitle(actor, rect);
+	const artY = rect.y + this.headerHeight();
+	const pairWidth = ImageManager.faceWidth + this.walkSpriteGap() + this.walkSpriteWidth();
+	const pairX = rect.x + Math.floor((rect.width - pairWidth) / 2);
+	this.drawActorFace(actor, pairX, artY, ImageManager.faceWidth, ImageManager.faceHeight);
+	const spriteCenterX = pairX + ImageManager.faceWidth + this.walkSpriteGap() + this.walkSpriteWidth() / 2;
+	this.drawActorWalkSprite(actor, Math.floor(spriteCenterX), artY + ImageManager.faceHeight);
+};
+/**
+* Draws the actor's name across the top of their cell, enlarged and centered.
+*
+* Enlarged because this is the one piece of text in the cell that identifies everything below it,
+* and centered because the artwork beneath it is centered- a left-aligned name over centered
+* portraits reads as a mistake rather than as a choice.
+* @param {Game_Actor} actor The actor being named.
+* @param {Rectangle} rect The bounds of the cell.
+*/
+Window_MenuStatus.prototype.drawActorNameHeader = function(actor, rect) {
+	this.contents.fontSize = $gameSystem.mainFontSize() + this.headerFontBoost();
+	this.drawText(actor.name(), rect.x, rect.y, rect.width, "center");
+	this.resetFontSettings();
+};
+/**
+* Draws the actor's class beneath their name, as a subtitle.
+*
+* Upper-cased and shrunk because it is a category rather than a proper noun- the name is who this
+* person is and the class is what they currently are, and the two carrying identical weight would
+* make the header read as two names. Tinted for the same reason, so the eye can tell at a glance
+* which line is the one it was looking for.
+* @param {Game_Actor} actor The actor whose class is being named.
+* @param {Rectangle} rect The bounds of the cell.
+*/
+Window_MenuStatus.prototype.drawActorClassSubtitle = function(actor, rect) {
+	this.resetFontSettings();
+	const className = actor.currentClass().name.toUpperCase();
+	const shrunk = this.modFontSizeForText(this.classSubtitleFontShrink(), className);
+	const subtitle = this.colorizeText(this.classSubtitleColorIndex(), shrunk);
+	const subtitleWidth = this.textSizeEx(subtitle).width;
+	const subtitleX = rect.x + Math.floor((rect.width - subtitleWidth) / 2);
+	this.drawTextEx(subtitle, subtitleX, rect.y + this.lineHeight(), rect.width);
+};
+/**
+* How much larger than body text the cell's name header is drawn.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.headerFontBoost = function() {
+	return 8;
+};
+/**
+* How much smaller than body text the class subtitle is drawn.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.classSubtitleFontShrink = function() {
+	return -6;
+};
+/**
+* The palette index the class subtitle is tinted with.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.classSubtitleColorIndex = function() {
+	return 1;
+};
+/**
+* The vertical space the name and class claim before the artwork begins.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.headerHeight = function() {
+	return this.lineHeight() * 2;
+};
+/**
+* Draws an actor's map sprite in its neutral standing pose, facing the player.
+*
+* The engine's own {@link Window_Base.drawCharacter} selects exactly this frame, but blits it at
+* native size, which leaves it dwarfed by the portrait beside it. This exists solely to draw that
+* same frame enlarged.
+*
+* Nothing here requests the sheet in advance. The party's own map sprites are necessarily cached by
+* the time a menu can be opened at all, and the scene refreshes this window again on start, which is
+* the same safety net the face graphics beside them have always relied on.
+* @param {Game_Actor} actor The actor whose map sprite is being drawn.
+* @param {number} x The horizontal center of the drawn sprite.
+* @param {number} y The baseline the sprite stands on.
+*/
+Window_MenuStatus.prototype.drawActorWalkSprite = function(actor, x, y) {
+	const characterName = actor.characterName();
+	const bitmap = ImageManager.loadCharacter(characterName);
+	const isBig = ImageManager.isBigCharacter(characterName);
+	const frameWidth = bitmap.width / (isBig ? 3 : 12);
+	const frameHeight = bitmap.height / (isBig ? 4 : 8);
+	const position = isBig ? 0 : actor.characterIndex();
+	const sourceX = (position % 4 * 3 + 1) * frameWidth;
+	const sourceY = Math.floor(position / 4) * 4 * frameHeight;
+	const scale = this.walkSpriteScale();
+	const drawWidth = frameWidth * scale;
+	const drawHeight = frameHeight * scale;
+	const destinationX = x - Math.floor(drawWidth / 2);
+	const destinationY = y - drawHeight;
+	const { context } = this.contents;
+	context.imageSmoothingEnabled = false;
+	this.contents.blt(bitmap, sourceX, sourceY, frameWidth, frameHeight, destinationX, destinationY, drawWidth, drawHeight);
+	context.imageSmoothingEnabled = true;
+};
+/**
+* How much larger than native the map sprite is drawn.
+*
+* Matching the portrait's height is the wrong target. Chibi proportions spend most of a frame on the
+* head, so a sprite standing as tall as a face does not read as its equal- it reads as looming. Two
+* keeps the sprite a companion to the portrait rather than a competitor, which is the relationship
+* worth preserving even if these proportions are later replaced with something less top-heavy.
+*
+* Whole numbers only- these are pixel art, and a fractional scale resamples them into mush.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.walkSpriteScale = function() {
+	return 2;
+};
+/**
+* The horizontal space the drawn map sprite claims.
+*
+* Derived from the map's tile size rather than measured off the sheet, because the layout has to
+* know this width before the sheet has necessarily finished loading.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.walkSpriteWidth = function() {
+	return $gameMap.tileWidth() * this.walkSpriteScale();
+};
+/**
+* Clear air between the face and the map sprite.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.walkSpriteGap = function() {
+	return 16;
 };
 /**
 * Overwrites {@link #drawItemStatus}.<br/>
 * Draws a member's details beneath their portrait.
 *
-* Deliberately sparse for now- name, level, class, and the basic gauges. What else belongs here is a
-* question better answered against a working skeleton than guessed at in advance.
+* Ordered by how often the answer is wanted rather than by how the data happens to be stored: how
+* far along they are, how they are holding up, what is currently wrong with them, and what they are
+* carrying. Each block is separated by a rule, because five stacks of text at one rhythm reads as a
+* single undifferentiated list no matter how well the individual rows are drawn.
 * @param {number} index The index of the party member being rendered.
 */
 Window_MenuStatus.prototype.drawItemStatus = function(index) {
 	const actor = this.actor(index);
 	const rect = this.itemRect(index);
-	const y = rect.y + ImageManager.faceHeight + this.lineHeight();
 	const padding = this.itemPadding();
 	const x = rect.x + padding;
 	const width = rect.width - padding * 2;
-	this.drawActorName(actor, x, y, width);
-	this.drawActorLevel(actor, x, y + this.lineHeight());
-	this.drawActorClass(actor, x, y + this.lineHeight() * 2, width);
-	this.placeBasicGauges(actor, x, y + this.lineHeight() * 3);
+	let y = rect.y + this.headerHeight() + ImageManager.faceHeight + this.sectionGap();
+	this.drawLevelAndExperience(actor, x, y, width);
+	y += this.lineHeight();
+	y = this.drawExtensionData(actor, x, y, width);
+	y = this.drawSectionBreak(x, y, width);
+	y = this.drawActorResources(actor, x, y, width);
+	y = this.drawSectionBreak(x, y, width);
+	this.drawActorStates(actor, x, y, width);
+	y += this.lineHeight();
+	y = this.drawSectionBreak(x, y, width);
+	this.drawEquipment(actor, x, y, width);
+};
+/**
+* Clear air on either side of the rule dividing one block of details from the next.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.sectionGap = function() {
+	return Math.floor(this.lineHeight() / 2);
+};
+/**
+* The thickness of the rule dividing one block of details from the next.
+*
+* Four rather than the two {@link Window_Base.drawHorizontalLine} defaults to, because that default
+* cannot draw its own color- see {@link #drawSectionBreak} for why.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.sectionRuleHeight = function() {
+	return 4;
+};
+/**
+* Draws the rule dividing one block of details from the next.
+*
+* Returns the y the following block begins at rather than expecting the caller to add the gap twice
+* and get it right- a divider is one thing, and the space it occupies should be one number.
+* @param {number} x The left edge of the rule.
+* @param {number} y The top of the space the divider occupies.
+* @param {number} width The width available to the rule.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.drawSectionBreak = function(x, y, width) {
+	const gap = this.sectionGap();
+	this.resetTextColor();
+	this.drawHorizontalLine(x, y + Math.floor(gap / 2), width, this.sectionRuleHeight());
+	return y + gap;
+};
+/**
+* Draws the actor's level and the distance to their next one as a single row.
+*
+* These are one thought rather than two- a level means little without knowing how close the next one
+* is, and separating them by three gauges is what left the experience readout looking stranded when
+* it lived on its own. The divider between them is what keeps a left-aligned and a right-aligned
+* value from reading as two unrelated pieces of text that happen to share a line.
+* @param {Game_Actor} actor The actor whose progress is being drawn.
+* @param {number} x The left edge of the row.
+* @param {number} y The top of the row.
+* @param {number} width The width available to the row.
+*/
+Window_MenuStatus.prototype.drawLevelAndExperience = function(actor, x, y, width) {
+	const levelValue = MenuStatusCatalog.levelValue(actor);
+	const experienceLabel = MenuStatusCatalog.experienceLabel(actor);
+	const iconY = y + Math.floor((this.lineHeight() - ImageManager.iconHeight) / 2);
+	this.drawIcon(IconManager.level(), x, iconY);
+	const levelMargin = ImageManager.standardIconWidth + 8;
+	this.resetTextColor();
+	this.drawText(levelValue, x + levelMargin, y, width - levelMargin, "left");
+	this.drawText(experienceLabel, x, y, width, "right");
+	const levelWidth = levelMargin + this.textWidth(levelValue);
+	const experienceWidth = this.textWidth(experienceLabel);
+	const gapWidth = width - levelWidth - experienceWidth;
+	if (gapWidth <= 0) return;
+	this.changePaintOpacity(false);
+	this.drawText(MenuStatusCatalog.LEVEL_DIVIDER, x + levelWidth, y, gapWidth, "center");
+	this.changePaintOpacity(true);
+};
+/**
+* Draws every resource this actor carries, one gauge per line.
+* @param {Game_Actor} actor The actor whose resources are being drawn.
+* @param {number} x The left edge of the block.
+* @param {number} y The top of the block.
+* @param {number} width The width available to each row.
+* @returns {number} The y coordinate immediately beneath the block.
+*/
+Window_MenuStatus.prototype.drawActorResources = function(actor, x, y, width) {
+	const rows = MenuStatusCatalog.resourceRows(actor);
+	rows.forEach((row, index) => {
+		const rowY = y + this.lineHeight() * index;
+		this.drawResourceRow(row, x, rowY, width);
+	});
+	return y + this.lineHeight() * rows.length;
+};
+/**
+* Draws a single resource as a label, a gauge, and the numbers behind it.
+*
+* The three share one line rather than stacking, because a resource is one fact and three lines of
+* vertical space is more than one fact is worth in a cell that has five other blocks to fit.
+* @param {{key: string, label: string, current: number, max: number, rate: number}} row The row.
+* @param {number} x The left edge of the row.
+* @param {number} y The top of the row.
+* @param {number} width The width available to the row.
+*/
+Window_MenuStatus.prototype.drawResourceRow = function(row, x, y, width) {
+	const iconY = y + Math.floor((this.lineHeight() - ImageManager.iconHeight) / 2);
+	this.drawIcon(this.resourceIconIndex(row.key), x, iconY);
+	this.resetTextColor();
+	this.drawText(`${row.current} / ${row.max}`, x, y, width, "right");
+	const gaugeX = x + this.resourceLabelWidth();
+	const gaugeWidth = width - this.resourceLabelWidth() - this.resourceValueWidth();
+	const gaugeY = y + Math.floor((this.lineHeight() - this.gaugeHeight()) / 2);
+	const gaugeRect = new Rectangle(gaugeX, gaugeY, gaugeWidth, this.gaugeHeight());
+	this.drawGauge(gaugeRect, row.rate, this.resourceGaugeOptions(row));
+};
+/**
+* Overwrites {@link Window_Base.gaugeHeight}.<br/>
+* The thickness of a gauge drawn in this window.
+*
+* J-Base's default of ten is sized for the tighter windows it was written against, and a ten pixel
+* bar sitting in a thirty-six pixel line reads as a hairline rather than as a measure of anything.
+* This window has the room to draw a gauge that looks like a gauge.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.gaugeHeight = function() {
+	return 18;
+};
+/**
+* The space reserved for a resource's icon before its gauge begins.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.resourceLabelWidth = function() {
+	return ImageManager.standardIconWidth + 12;
+};
+/**
+* The icon standing for a given resource.
+*
+* An icon rather than the database's abbreviation, because the abbreviations are two letters that
+* differ by one character and the icons are distinguishable at a glance- which is the whole job of
+* the leftmost thing on a row the player is scanning rather than reading.
+*
+* Resolved through IconManager for the same reason the colors are resolved through ColorManager: a
+* resource should look the way it looks everywhere else in the game, and neither decision belongs
+* to this window.
+* @param {string} key Which resource is being marked, being one of 'hp', 'mp', or 'tp'.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.resourceIconIndex = function(key) {
+	switch (key) {
+		case "mp": return IconManager.param(1);
+		case "tp": return IconManager.maxTp();
+		default: return IconManager.param(0);
+	}
+};
+/**
+* The space reserved for a resource's current and maximum values.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.resourceValueWidth = function() {
+	return 160;
+};
+/**
+* Builds the styling for a resource gauge.
+*
+* Kept as one method taking the whole row so that changing the house style is a single edit- these
+* four gauge shapes are trivially interchangeable, and settling on one is a matter of looking at
+* them rather than of reasoning about them.
+*
+* Segmented rather than solid because a solid bar answers "how full" and a segmented one also
+* answers "how much", which is the more useful question when the number beside it is the thing the
+* player is actually budgeting against.
+* @param {{key: string, label: string, current: number, max: number, rate: number}} row The row.
+* @returns {WindowGaugeOptions}
+*/
+Window_MenuStatus.prototype.resourceGaugeOptions = function(row) {
+	const [leftColor, rightColor] = this.resourceGaugeColors(row.key);
+	const segments = Math.max(1, Math.ceil(row.max / this.resourceSegmentValue()));
+	return WindowGaugeOptions.Builder().gaugeType(Window_Base.GAUGE_TYPES.Segmented).segments(segments).gap(2).leftGradientColor(leftColor).rightGradientColor(rightColor).backColor(this.gaugeBackColor()).build();
+};
+/**
+* How much of a resource one segment of its gauge stands for.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.resourceSegmentValue = function() {
+	return 20;
+};
+/**
+* The gradient a given resource's gauge is drawn in.
+*
+* Deferred to the engine's own gauge colors rather than chosen here, so a resource looks the same in
+* this menu as it does everywhere else the player has already learned to read it.
+* @param {string} key Which resource the gauge renders, being one of 'hp', 'mp', or 'tp'.
+* @returns {[string, string]}
+*/
+Window_MenuStatus.prototype.resourceGaugeColors = function(key) {
+	switch (key) {
+		case "mp": return [ColorManager.mpGaugeColor1(), ColorManager.mpGaugeColor2()];
+		case "tp": return [ColorManager.tpGaugeColor1(), ColorManager.tpGaugeColor2()];
+		default: return [ColorManager.hpGaugeColor1(), ColorManager.hpGaugeColor2()];
+	}
+};
+/**
+* Draws the icons of every state currently afflicting this actor.
+*
+* An actor suffering nothing says so in words rather than leaving the row blank. A blank row reads
+* as something that failed to load; "Unafflicted" reads as good news, and good news is worth the
+* line it costs.
+* @param {Game_Actor} actor The actor whose afflictions are being drawn.
+* @param {number} x The left edge of the row.
+* @param {number} y The top of the row.
+* @param {number} width The width available to the row.
+*/
+Window_MenuStatus.prototype.drawActorStates = function(actor, x, y, width) {
+	const iconIndices = MenuStatusCatalog.stateIcons(actor);
+	if (iconIndices.length === 0) {
+		this.changePaintOpacity(false);
+		this.drawText(MenuStatusCatalog.UNAFFLICTED_TEXT, x, y, width, "left");
+		this.changePaintOpacity(true);
+		return;
+	}
+	const iconY = y + Math.floor((this.lineHeight() - ImageManager.iconHeight) / 2);
+	iconIndices.forEach((iconIndex, index) => {
+		const iconX = x + index * (ImageManager.standardIconWidth + 4);
+		this.drawIcon(iconIndex, iconX, iconY);
+	});
+};
+/**
+* Draws everything this actor is wearing, one slot per line.
+* @param {Game_Actor} actor The actor whose loadout is being drawn.
+* @param {number} x The left edge of the block.
+* @param {number} y The top of the block.
+* @param {number} width The width available to each row.
+* @returns {number} The y coordinate immediately beneath the block.
+*/
+Window_MenuStatus.prototype.drawEquipment = function(actor, x, y, width) {
+	const rows = MenuStatusCatalog.equipmentRows(actor);
+	rows.forEach((row, index) => {
+		const rowY = y + this.lineHeight() * index;
+		this.drawEquipmentRow(row, x, rowY, width);
+	});
+	return y + this.lineHeight() * rows.length;
+};
+/**
+* Draws a single equipment slot.
+*
+* A filled slot needs no label- the item's own icon and name identify it more precisely than the slot
+* name ever could. An empty one has neither, so it borrows the name of the slot it stands for and is
+* drawn dimmed, which is what keeps a run of empty slots reading as absences rather than as more gear.
+* @param {{item: RPG_EquipItem, slotName: string, isEquipped: boolean}} row The row to draw.
+* @param {number} x The left edge of the row.
+* @param {number} y The top of the row.
+* @param {number} width The width available to the row.
+*/
+Window_MenuStatus.prototype.drawEquipmentRow = function(row, x, y, width) {
+	if (row.isEquipped) {
+		this.drawItemName(row.item, x, y, width);
+		return;
+	}
+	const textMargin = ImageManager.standardIconWidth + 4;
+	const textX = x + textMargin;
+	const textWidth = Math.max(0, width - textMargin);
+	this.changePaintOpacity(false);
+	this.drawText(`${row.slotName} - ${MenuStatusCatalog.EMPTY_SLOT_TEXT}`, textX, y, textWidth);
+	this.changePaintOpacity(true);
+};
+/**
+* Draws whatever other plugins have to contribute about this actor's advancement.
+*
+* Deliberately empty. J-CMS knows nothing about the systems layered on top of it, and the things
+* genuinely worth a row here- unspent node points, for one- belong to the plugins that own them.
+* Those plugins alias this method rather than J-CMS reaching across for data it has no business
+* knowing about.
+*
+* Positioned alongside level and experience rather than at the foot of the cell, because what an
+* extension has to say about a character is almost always another measure of how far along they
+* are, and a currency waiting to be spent belongs beside the two numbers it will be spent on- not
+* stranded beneath their gear.
+*
+* An implementation must return the y its own drawing ended at, so that several extensions can each
+* claim a row without any of them knowing what the others drew. Doing nothing returns the y it was
+* given, which costs the cell no space at all.
+* @param {Game_Actor} _actor The actor being described.
+* @param {number} _x The left edge of the space available.
+* @param {number} y The top of the space available.
+* @param {number} _width The width available.
+* @returns {number}
+*/
+Window_MenuStatus.prototype.drawExtensionData = function(_actor, _x, y, _width) {
+	return y;
 };
 
 //#endregion
@@ -1298,7 +1907,7 @@ Scene_Menu.prototype.helpWindowLineCount = function() {
 */
 Scene_Menu.prototype.statusWindowRect = function() {
 	const wy = this.helpWindowRect().height;
-	const wh = Graphics.boxHeight - wy - this.goldWindowRect().height;
+	const wh = this.goldWindowRect().y - wy;
 	return new Rectangle(this.centerStackX(), wy, this.centerStackWidth(), wh);
 };
 /**

--- a/chef-adventure/js/plugins/j/diff/J-Difficulty.js
+++ b/chef-adventure/js/plugins/j/diff/J-Difficulty.js
@@ -2,7 +2,7 @@
  
 /*:
  * @target MZ
- * @plugindesc [v2.1.0 DIFFICULTY] A layered difficulty system.
+ * @plugindesc [v2.1.1 DIFFICULTY] A layered difficulty system.
  * @base J-Base
  * @orderAfter J-Base
  * @author JE
@@ -23,6 +23,11 @@
  * All difficulties are defined in an external JSON file.
  * ============================================================================
  * CHANGELOG:
+ * - 2.1.1
+ *    The difficulty points window no longer declares private members. A
+ *    window's constructor reaches initialize, and through it the drawing
+ *    hooks, before a derived class installs its own members- so anything
+ *    private was being touched on an object that did not yet have it.
  * - 2.1.0
  *    Routed the _difficulty namespace into its own save section, so difficulty
  *    state lands in systems/difficulty.json rather than in the system blob.
@@ -838,7 +843,7 @@ J.DIFFICULTY = {};
 /**
 * The `metadata` associated with this plugin, such as version.
 */
-J.DIFFICULTY.Metadata = new J_DiffPluginMetadata("J-Difficulty", "2.1.0");
+J.DIFFICULTY.Metadata = new J_DiffPluginMetadata("J-Difficulty", "2.1.1");
 /**
 * The actual `plugin parameters` extracted from RMMZ.
 */
@@ -1482,7 +1487,7 @@ var Window_DifficultyPoints = class extends Window_Base {
 	* The difficulty layer that the cursor is currently hovering over.
 	* @type {DifficultyLayer|null}
 	*/
-	#hoveredDifficulty = null;
+	_hoveredDifficulty = null;
 	/**
 	* Constructor.
 	* @param {Rectangle} rect The rectangle that represents this window.
@@ -1495,14 +1500,14 @@ var Window_DifficultyPoints = class extends Window_Base {
 	* @returns {DifficultyLayer}
 	*/
 	getHoveredDifficulty() {
-		return this.#hoveredDifficulty;
+		return this._hoveredDifficulty;
 	}
 	/**
 	* Set the currently hovered difficulty used by this window.
 	* @param {DifficultyLayer} difficulty The difficulty currently hovered.
 	*/
 	setHoveredDifficulty(difficulty) {
-		this.#hoveredDifficulty = difficulty;
+		this._hoveredDifficulty = difficulty;
 	}
 	/**
 	* Implements {@link Window_Base.drawContent}.<br/>

--- a/chef-adventure/js/plugins/j/extend/J-Extend.js
+++ b/chef-adventure/js/plugins/j/extend/J-Extend.js
@@ -1,7 +1,7 @@
 //region Introduction
 /*:
  * @target MZ
- * @plugindesc [v1.7.1 EXTEND] Extends the capabilities of skills/actions.
+ * @plugindesc [v1.7.2 EXTEND] Extends the capabilities of skills/actions.
  * @base J-Base
  * @orderAfter J-Base
  * @author JE
@@ -433,6 +433,11 @@
  * A three-state cycle: 12 -> 13 -> 14 -> 12 -> ..., one step per execution.
  * ============================================================================
  * CHANGELOG:
+ * - 1.7.2
+ *    The plugin metadata class no longer declares private members. Its base
+ *    constructor reaches postInitialize before a derived class installs its
+ *    own, so anything private was being touched on an object that did not yet
+ *    have it.
  * - 1.7.1
  *    Split Game_Item's extension state so the default lands in initMembers
  *    while the mapping from the constructed item stays in the initialize
@@ -517,7 +522,7 @@ var J_SkillExtendPluginMetadata = class extends PluginMetadata {
 	* Plugins opt in by calling {@link registerNonCombiningKey} during Scene_Boot.
 	* @type {Set<string>}
 	*/
-	#nonCombiningKeys = new Set();
+	_nonCombiningKeys = new Set();
 	/**
 	* Constructor.
 	*/
@@ -533,14 +538,23 @@ var J_SkillExtendPluginMetadata = class extends PluginMetadata {
 	*/
 	registerNonCombiningKey(regexp, asBoolean = false) {
 		const key = J.BASE.Helpers.getKeyFromRegexp(regexp, asBoolean).toLowerCase();
-		this.#nonCombiningKeys.add(key);
+		this.nonCombiningKeys().add(key);
+	}
+	/**
+	* The live set of registered non-combining tag keys.
+	* Registration mutates this set directly; readers should prefer {@link getNonCombiningKeys}, which
+	* hands back a copy rather than the collection itself.
+	* @returns {Set<string>} The backing set.
+	*/
+	nonCombiningKeys() {
+		return this._nonCombiningKeys;
 	}
 	/**
 	* Gets all registered non-combining tag keys as an array.
 	* @returns {string[]} The registered keys, all lowercase.
 	*/
 	getNonCombiningKeys() {
-		return [...this.#nonCombiningKeys];
+		return [...this.nonCombiningKeys()];
 	}
 };
 
@@ -564,7 +578,7 @@ J.EXTEND = {};
 /**
 * The `metadata` associated with this plugin, such as version.
 */
-J.EXTEND.Metadata = new J_SkillExtendPluginMetadata("J-Extend", "1.7.1");
+J.EXTEND.Metadata = new J_SkillExtendPluginMetadata("J-Extend", "1.7.2");
 /**
 * A collection of all aliased methods for this plugin.
 */

--- a/chef-adventure/js/plugins/j/hud/ext/J-HUD-Food.js
+++ b/chef-adventure/js/plugins/j/hud/ext/J-HUD-Food.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.0.0 HUD-FOOD] A J-HUD extension that displays the current food chain status on screen.
+ * [v1.0.1 HUD-FOOD] A J-HUD extension that displays the current food chain status on screen.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -25,6 +25,11 @@
  * Those responsibilities belong to J-ABS-Food.
  * ============================================================================
  * CHANGELOG:
+ * - 1.0.1
+ *    The food frame no longer declares private members. A window's constructor
+ *    reaches initialize, and through it the drawing hooks, before a derived
+ *    class installs its own members- so anything private was being touched on
+ *    an object that did not yet have it.
  * - 1.0.0
  *    Initial release.
  * ============================================================================
@@ -152,7 +157,7 @@ J.HUD.EXT.FOOD ||= {};
 /**
 * The metadata associated with this plugin.
 */
-J.HUD.EXT.FOOD.Metadata = new JFoodHud_PluginMetadata("J-HUD-FOOD", "1.0.0");
+J.HUD.EXT.FOOD.Metadata = new JFoodHud_PluginMetadata("J-HUD-FOOD", "1.0.1");
 /**
 * A collection of all aliased methods for this plugin.
 */
@@ -317,22 +322,22 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 			this.hide();
 			return;
 		}
-		const activeId = this.#resolveActiveStateId(leader, plan);
+		const activeId = this.resolveActiveStateId(leader, plan);
 		if (activeId === 0) {
 			this.hide();
 			return;
 		}
 		this.show();
-		this.#drawActiveStateIcon(activeId);
-		this.#drawVerticalBar(plan, player.getUuid(), activeId);
-		this.#drawChainLabels(plan, activeId);
+		this.drawActiveStateIcon(activeId);
+		this.drawVerticalBar(plan, player.getUuid(), activeId);
+		this.drawChainLabels(plan, activeId);
 	}
 	/**
 	* Draws the icon of the currently active food chain state, centered at the top
 	* of the content area.
 	* @param {number} activeId The state id currently active on the leader.
 	*/
-	#drawActiveStateIcon(activeId) {
+	drawActiveStateIcon(activeId) {
 		const iconIndex = $dataStates[activeId] ? $dataStates[activeId].iconIndex : 0;
 		const iconX = Math.floor((this.contentsWidth() - ImageManager.iconWidth) / 2);
 		this.drawIcon(iconIndex, iconX, Window_FoodFrame.ICON_Y);
@@ -349,7 +354,7 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 	* @param {string} uuid The UUID of the leader's JABS battler for duration lookup.
 	* @param {number} activeId The state id currently active on the leader.
 	*/
-	#drawVerticalBar(plan, uuid, activeId) {
+	drawVerticalBar(plan, uuid, activeId) {
 		const { segments } = plan;
 		const totalFrames = segments.reduce((sum, seg) => sum + seg.frames, 0);
 		if (totalFrames <= 0) return;
@@ -357,7 +362,7 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 		const barY = Window_FoodFrame.BAR_START_Y;
 		const barW = Window_FoodFrame.BAR_WIDTH;
 		const barH = Window_FoodFrame.BAR_HEIGHT;
-		this.#drawBarFrame(barX, barY, barW, barH);
+		this.drawBarFrame(barX, barY, barW, barH);
 		const inner = Window_FoodFrame.#barInnerRect(barX, barY, barW, barH);
 		const activeIndex = plan.indexOfState(activeId);
 		let cumY = inner.y;
@@ -371,7 +376,7 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 			}
 			if (segH <= 0) continue;
 			const isActive = i === activeIndex;
-			this.#drawBarSegment(inner.x, cumY, inner.width, segH, segment, i, activeIndex, isActive, uuid, isLast);
+			this.drawBarSegment(inner.x, cumY, inner.width, segH, segment, i, activeIndex, isActive, uuid, isLast);
 			cumY += segH;
 		}
 	}
@@ -382,11 +387,11 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 	* @param {number} width Outer width including the frame.
 	* @param {number} height Outer height including the frame.
 	*/
-	#drawBarFrame(x, y, width, height) {
+	drawBarFrame(x, y, width, height) {
 		const border = Window_FoodFrame.BAR_BORDER_THICKNESS;
 		this.contents.fillRect(x, y, width, height, Window_FoodFrame.BAR_FRAME_COLOR);
 		this.contents.fillRect(x + border, y + border, width - border * 2, height - border * 2, ColorManager.gaugeBackColor());
-		this.#strokeBarOutline(x, y, width, height);
+		this.strokeBarOutline(x, y, width, height);
 	}
 	/**
 	* Strokes a 1px rectangle around the outer bar bounds.
@@ -395,7 +400,7 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 	* @param {number} width Outer width including the frame.
 	* @param {number} height Outer height including the frame.
 	*/
-	#strokeBarOutline(x, y, width, height) {
+	strokeBarOutline(x, y, width, height) {
 		const ctx = this.contents.context;
 		ctx.save();
 		ctx.beginPath();
@@ -435,12 +440,12 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 	* @param {string} uuid UUID for JABS state tracker duration lookup.
 	* @param {boolean} isLast Whether this is the final slice in the chain (touches the track floor).
 	*/
-	#drawBarSegment(x, y, width, height, segment, index, activeIndex, isActive, uuid, isLast) {
+	drawBarSegment(x, y, width, height, segment, index, activeIndex, isActive, uuid, isLast) {
 		const bgColor = ColorManager.gaugeBackColor();
 		if (index < activeIndex) {
 			this.contents.fillRect(x, y, width, height, bgColor);
 		} else if (isActive) {
-			const fillRatio = this.#calculateFillRatio(segment, uuid);
+			const fillRatio = this.calculateFillRatio(segment, uuid);
 			let fillH = Math.round(height * fillRatio);
 			fillH = Math.max(0, Math.min(height, fillH));
 			this.contents.fillRect(x, y, width, height, bgColor);
@@ -461,7 +466,7 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 	* @param {JABS_FoodChainPlan} plan The active food chain plan.
 	* @param {number} activeId The state id currently active on the leader.
 	*/
-	#drawChainLabels(plan, activeId) {
+	drawChainLabels(plan, activeId) {
 		const { segments } = plan;
 		const rowH = Window_FoodFrame.LABEL_ROW_HEIGHT;
 		const activeIndex = plan.indexOfState(activeId);
@@ -471,7 +476,7 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 			if (!state) continue;
 			const labelY = Window_FoodFrame.LABELS_START_Y + i * rowH;
 			const isActive = i === activeIndex;
-			this.#drawChainLabel(state.name, labelY, isActive);
+			this.drawChainLabel(state.name, labelY, isActive);
 		}
 	}
 	/**
@@ -480,14 +485,14 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 	* @param {number} y The y coordinate in contents space.
 	* @param {boolean} isActive Whether this row is the currently active chain phase.
 	*/
-	#drawChainLabel(rawName, y, isActive) {
+	drawChainLabel(rawName, y, isActive) {
 		let text = this.convertEscapeCharacters(rawName);
-		text = this.#applyChainLabelFontSize(text);
+		text = this.applyChainLabelFontSize(text);
 		if (isActive) {
 			text = this.boldenText(this.italicizeText(text));
 		}
 		const { width: textWidth } = this.textSizeEx(text);
-		const drawX = this.#chainLabelCenterX(textWidth);
+		const drawX = this.chainLabelCenterX(textWidth);
 		const drawWidth = Math.min(textWidth, this.contentsWidth());
 		if (isActive) {
 			this.drawTextEx(text, drawX, y, drawWidth);
@@ -504,7 +509,7 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 	* @param {number} textWidth The measured width of the label text.
 	* @returns {number}
 	*/
-	#chainLabelCenterX(textWidth) {
+	chainLabelCenterX(textWidth) {
 		const contentsW = this.contentsWidth();
 		if (textWidth >= contentsW) {
 			return 0;
@@ -516,7 +521,7 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 	* @param {string} text The label text (may already include escape codes).
 	* @returns {string}
 	*/
-	#applyChainLabelFontSize(text) {
+	applyChainLabelFontSize(text) {
 		return this.modFontSizeForText(Window_FoodFrame.CHAIN_LABEL_FONT_DELTA, text);
 	}
 	/**
@@ -526,7 +531,7 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 	* @param {JABS_FoodChainPlan} plan The active food chain plan.
 	* @returns {number} The active state id, or 0.
 	*/
-	#resolveActiveStateId(leader, plan) {
+	resolveActiveStateId(leader, plan) {
 		for (const segment of plan.segments) {
 			if (leader.isStateAffected(segment.stateId)) return segment.stateId;
 		}
@@ -540,7 +545,7 @@ var Window_FoodFrame = class Window_FoodFrame extends Window_Base {
 	* @param {string} uuid UUID for the JABS battler state tracker.
 	* @returns {number} Fill ratio clamped to [0, 1].
 	*/
-	#calculateFillRatio(segment, uuid) {
+	calculateFillRatio(segment, uuid) {
 		const jabsStateMap = $jabsEngine.getJabsStatesByUuid(uuid);
 		if (!jabsStateMap) return 1;
 		const jabsState = jabsStateMap.get(segment.stateId);

--- a/chef-adventure/js/plugins/j/jafting/ext/J-JAFTING-Creation.js
+++ b/chef-adventure/js/plugins/j/jafting/ext/J-JAFTING-Creation.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.2.0 JAFTING-CREATE] An extension for JAFTING to enable recipe creation.
+ * [v1.2.1 JAFTING-CREATE] An extension for JAFTING to enable recipe creation.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -139,6 +139,11 @@
  * the J-MZ Data Editor app), not tagged on individual database objects.
  * ============================================================================
  * CHANGELOG:
+ * - 1.2.1
+ *    The plugin metadata class and the category badge and recipe detail
+ *    windows no longer declare private members. Both base constructors reach
+ *    an overridable hook before a derived class installs its own members- so
+ *    anything private was being touched on an object that did not yet have it.
  * - 1.2.0
  *    Routed the _crafting namespace into its own save section, so recipe and
  *    category tracking land in systems/crafting.json.
@@ -1224,15 +1229,15 @@ var J_CraftingCreatePluginMetadata = class J_CraftingCreatePluginMetadata extend
 	* @return {boolean}
 	*/
 	usingSdp() {
-		if (!this.#hasSdpConnection()) return false;
-		if (!this.#hasMinimumSdpVersion()) return false;
+		if (!this.hasSdpConnection()) return false;
+		if (!this.hasMinimumSdpVersion()) return false;
 		return true;
 	}
 	/**
 	* Checks if the plugin metadata is detected for the SDP system.
 	* @return {boolean}
 	*/
-	#hasSdpConnection() {
+	hasSdpConnection() {
 		if (!PluginMetadata.hasPlugin("J-SDP")) return false;
 		return true;
 	}
@@ -1241,8 +1246,8 @@ var J_CraftingCreatePluginMetadata = class J_CraftingCreatePluginMetadata extend
 	* connecting with this crafting system.
 	* @return {boolean}
 	*/
-	#hasMinimumSdpVersion() {
-		const minimumVersion = this.#minimumSdpVersion();
+	hasMinimumSdpVersion() {
+		const minimumVersion = this.minimumSdpVersion();
 		const meetsThreshold = J.SDP.Metadata.version.satisfiesPluginVersion(minimumVersion);
 		if (!meetsThreshold) return false;
 		return true;
@@ -1252,7 +1257,7 @@ var J_CraftingCreatePluginMetadata = class J_CraftingCreatePluginMetadata extend
 	* this crafting will communicate with.
 	* @return {PluginVersion}
 	*/
-	#minimumSdpVersion() {
+	minimumSdpVersion() {
 		return PluginVersion.builder.major("2").minor("0").patch("0").build();
 	}
 	/**
@@ -1304,7 +1309,7 @@ J.JAFTING.EXT.CREATE = {};
 /**
 * The metadata associated with this plugin.
 */
-J.JAFTING.EXT.CREATE.Metadata = new J_CraftingCreatePluginMetadata("J-JAFTING-Creation", "1.2.0");
+J.JAFTING.EXT.CREATE.Metadata = new J_CraftingCreatePluginMetadata("J-JAFTING-Creation", "1.2.1");
 /**
 * A collection of all aliased methods for this plugin.
 */
@@ -1677,7 +1682,7 @@ var Window_CreationCategoryBadge = class extends Window_Base {
 	/**
 	* @type {CraftingCategory|null}
 	*/
-	#category = null;
+	_category = null;
 	/**
 	* @param {Rectangle} rect The rectangle that represents this window.
 	*/
@@ -1688,25 +1693,33 @@ var Window_CreationCategoryBadge = class extends Window_Base {
 	* @param {CraftingCategory|null} category The category to render, or null to clear.
 	*/
 	setCategory(category) {
-		this.#category = category;
+		this._category = category;
 		this.refresh();
 	}
 	/**
 	* Clears the badge contents (used when leaving recipe browsing).
 	*/
 	clearCategory() {
-		this.#category = null;
+		this._category = null;
 		this.refresh();
+	}
+	/**
+	* The category this badge is currently rendering, or null when cleared.
+	* @returns {CraftingCategory|null}
+	*/
+	category() {
+		return this._category;
 	}
 	/**
 	* Implements {@link Window_Base.drawContent}.
 	*/
 	drawContent() {
-		if (this.#category === null) {
+		const category = this.category();
+		if (category === null) {
 			return;
 		}
 		this.resetFontSettings();
-		const { iconIndex, name } = this.#category;
+		const { iconIndex, name } = category;
 		const lh = this.lineHeight();
 		const iy = Math.floor((this.innerHeight - lh) / 2);
 		const iconSlot = ImageManager.standardIconWidth + 8;
@@ -1874,7 +1887,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	* The currently selected recipe being detailed.
 	* @type {CraftingRecipe}
 	*/
-	#currentRecipe = null;
+	_currentRecipe = null;
 	/**
 	* True if the text of this list should be masked, false otherwise.
 	* @type {boolean}
@@ -1884,10 +1897,10 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 		super(rect);
 	}
 	getCurrentRecipe() {
-		return this.#currentRecipe;
+		return this._currentRecipe;
 	}
 	setCurrentRecipe(recipe) {
-		this.#currentRecipe = recipe;
+		this._currentRecipe = recipe;
 	}
 	setNeedsMasking(needsMasking) {
 		this.needsMasking = needsMasking;
@@ -1916,15 +1929,15 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	* @returns {number}
 	*/
 	componentListRowsInnerStartY() {
-		return this.#recipeComponentHeaderBandEndInnerY();
+		return this.recipeComponentHeaderBandEndInnerY();
 	}
 	/**
 	* Inner Y just below the unified horizontal rules under INGREDIENTS / TOOLS / OUTPUTS.
 	* @returns {number}
 	*/
-	#recipeComponentHeaderBandEndInnerY() {
+	recipeComponentHeaderBandEndInnerY() {
 		const cw = this.detailsQuarterWidth();
-		const { ruleTopY } = this.#tripleColumnHeaderRuleTopInnerY(cw);
+		const { ruleTopY } = this.tripleColumnHeaderRuleTopInnerY(cw);
 		const ruleH = Window_RecipeDetails.#COMPONENT_HEADER_RULE_HEIGHT;
 		const gapAfterRule = Window_RecipeDetails.#COMPONENT_HEADER_RULE_GAP_AFTER;
 		return ruleTopY + ruleH + gapAfterRule;
@@ -1932,7 +1945,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	/**
 	* Prepares the smaller italic face used under column titles.
 	*/
-	#prepareItalicsSubtextFont() {
+	prepareItalicsSubtextFont() {
 		this.resetFontSettings();
 		this.modFontSize(-12);
 		this.toggleItalics();
@@ -1940,7 +1953,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	/**
 	* Restores default font after italic subtext measurement or drawing.
 	*/
-	#restoreAfterItalicsSubtextFont() {
+	restoreAfterItalicsSubtextFont() {
 		this.toggleItalics();
 		this.resetFontSettings();
 	}
@@ -1951,7 +1964,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	* @param {number} maxWidth The max width driving this step.
 	* @returns {string[]}
 	*/
-	#splitLongToken(token, maxWidth) {
+	splitLongToken(token, maxWidth) {
 		const segments = [];
 		let chunk = "";
 		for (let ci = 0; ci < token.length; ci++) {
@@ -1970,7 +1983,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 		}
 		return segments;
 	}
-	#wrapPlainTextToLines(text, maxWidth) {
+	wrapPlainTextToLines(text, maxWidth) {
 		if (text === "") {
 			return [""];
 		}
@@ -1991,7 +2004,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 			if (this.textWidth(word) <= maxWidth) {
 				line = word;
 			} else {
-				const segments = this.#splitLongToken(word, maxWidth);
+				const segments = this.splitLongToken(word, maxWidth);
 				for (let si = 0; si < segments.length; si++) {
 					if (si < segments.length - 1) {
 						lines.push(segments[si]);
@@ -2016,11 +2029,11 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	* @param {number} bandWidth The band width driving this step.
 	* @returns {string[]}
 	*/
-	#measureItalicSubtextLines(subtext, bandWidth) {
-		this.#prepareItalicsSubtextFont();
+	measureItalicSubtextLines(subtext, bandWidth) {
+		this.prepareItalicsSubtextFont();
 		const usableW = Math.max(1, bandWidth - 4);
-		const lines = this.#wrapPlainTextToLines(subtext, usableW);
-		this.#restoreAfterItalicsSubtextFont();
+		const lines = this.wrapPlainTextToLines(subtext, usableW);
+		this.restoreAfterItalicsSubtextFont();
 		return lines;
 	}
 	/**
@@ -2029,15 +2042,15 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	* @param {number} cw column inner width
 	* @returns {{ ruleTopY: number, layouts: { titleH: number, lines: string[], subLineHeight: number }[] }}
 	*/
-	#tripleColumnHeaderRuleTopInnerY(cw) {
+	tripleColumnHeaderRuleTopInnerY(cw) {
 		const subtexts = [
 			Window_RecipeDetails.#SUBTEXT_INGREDIENTS,
 			Window_RecipeDetails.#SUBTEXT_TOOLS,
 			Window_RecipeDetails.#SUBTEXT_OUTPUTS
 		];
-		this.#prepareItalicsSubtextFont();
+		this.prepareItalicsSubtextFont();
 		const subLineHeight = this.lineHeight();
-		this.#restoreAfterItalicsSubtextFont();
+		this.restoreAfterItalicsSubtextFont();
 		const layouts = [];
 		for (let i = 0; i < 3; i++) {
 			this.resetFontSettings();
@@ -2045,7 +2058,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 			this.toggleBold();
 			const titleH = this.lineHeight();
 			this.toggleBold();
-			const lines = this.#measureItalicSubtextLines(subtexts[i], cw);
+			const lines = this.measureItalicSubtextLines(subtexts[i], cw);
 			layouts.push({
 				titleH,
 				lines,
@@ -2077,19 +2090,19 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	* @param {string[]} lines The lines driving this step.
 	* @param {number} subLineHeight The sub line height driving this step.
 	*/
-	#drawColumnTitleAndSubtext(x, y, bandWidth, title, lines, subLineHeight) {
+	drawColumnTitleAndSubtext(x, y, bandWidth, title, lines, subLineHeight) {
 		this.resetFontSettings();
 		this.modFontSize(4);
 		this.toggleBold();
 		this.drawText(title, x, y, bandWidth, Window_Base.TextAlignments.Left);
 		let cursor = y + this.lineHeight();
 		this.toggleBold();
-		this.#prepareItalicsSubtextFont();
+		this.prepareItalicsSubtextFont();
 		for (let li = 0; li < lines.length; li++) {
 			this.drawText(lines[li], x, cursor, bandWidth, Window_Base.TextAlignments.Left);
 			cursor += subLineHeight;
 		}
-		this.#restoreAfterItalicsSubtextFont();
+		this.restoreAfterItalicsSubtextFont();
 	}
 	/**
 	* Width of each of the four bands (ingredients, tools, outputs, detail pane).
@@ -2119,11 +2132,11 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	* Draws the recipe details header bands and the primary output column.
 	*/
 	drawContent() {
-		if (!this.#canDrawContent()) return;
+		if (!this.canDrawContent()) return;
 		const [x, y] = [0, 0];
 		const { cw, remainder } = Window_RecipeDetails.quarterWidthsFromInner(this.innerWidth);
 		const wDetail = cw + remainder;
-		const { ruleTopY, layouts } = this.#tripleColumnHeaderRuleTopInnerY(cw);
+		const { ruleTopY, layouts } = this.tripleColumnHeaderRuleTopInnerY(cw);
 		const titles = [
 			"INGREDIENTS",
 			"TOOLS",
@@ -2133,7 +2146,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 		const ruleH = Window_RecipeDetails.#COMPONENT_HEADER_RULE_HEIGHT;
 		for (let col = 0; col < 3; col++) {
 			const L = layouts[col];
-			this.#drawColumnTitleAndSubtext(x + cw * col, y, cw, titles[col], L.lines, L.subLineHeight);
+			this.drawColumnTitleAndSubtext(x + cw * col, y, cw, titles[col], L.lines, L.subLineHeight);
 			const ruleW = Math.max(1, cw - inset * 2);
 			this.drawHorizontalLine(x + cw * col + inset, ruleTopY, ruleW, ruleH);
 		}
@@ -2143,8 +2156,8 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	* Determines if the content for this window can be drawn.
 	* @return {boolean}
 	*/
-	#canDrawContent() {
-		if (this.#currentRecipe === undefined || this.#currentRecipe === null) return false;
+	canDrawContent() {
+		if (this.getCurrentRecipe() === undefined || this.getCurrentRecipe() === null) return false;
 		return true;
 	}
 	/**
@@ -2157,10 +2170,10 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 		this.drawVerticalLine(x - Window_RecipeDetails.#DETAIL_DIVIDER_LEFT_OFFSET, y, this.innerHeight, 3);
 		const lh = this.lineHeight();
 		const textW = Math.max(48, bandWidth - 8);
-		const proficiency = `Proficiency: ${this.#currentRecipe.getProficiency()}`;
+		const proficiency = `Proficiency: ${this.getCurrentRecipe().getProficiency()}`;
 		this.drawText(proficiency, x, y, textW);
 		const bodyY = this.componentListRowsInnerStartY();
-		const primaryOutput = this.#currentRecipe.outputs.at(0);
+		const primaryOutput = this.getCurrentRecipe().outputs.at(0);
 		switch (primaryOutput.getComponentType()) {
 			case CraftingComponent.Types.Item:
 				this.drawPrimaryOutputItem(x, bodyY);
@@ -2182,7 +2195,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	}
 	drawPrimaryOutputItem(x, y) {
 		const lh = this.lineHeight() - 4;
-		const output = this.#currentRecipe.outputs.at(0).getItem();
+		const output = this.getCurrentRecipe().outputs.at(0).getItem();
 		const lifeY = y + lh * 1;
 		this.drawLifeMessage(output, x, lifeY);
 		const magiY = y + lh * 2;
@@ -2274,7 +2287,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	}
 	drawFoodStateChanges(output, x, y) {
 		this.resetFontSettings();
-		const foodStateEffects = output.effects.filter((effect) => effect.code === Game_Action.EFFECT_ADD_STATE && this.#foodStateIds().includes(effect.dataId));
+		const foodStateEffects = output.effects.filter((effect) => effect.code === Game_Action.EFFECT_ADD_STATE && this.foodStateIds().includes(effect.dataId));
 		const lh = this.lineHeight() - 4;
 		const forEacher = (foodStateEffect, index) => {
 			/** @type {RPG_State} */
@@ -2290,7 +2303,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 		};
 		foodStateEffects.forEach(forEacher, this);
 	}
-	#foodStateIds() {
+	foodStateIds() {
 		return [
 			82,
 			83,
@@ -2303,7 +2316,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	}
 	drawPrimaryOutputWeaponOrArmor(x, y) {
 		const lh = this.lineHeight() - 4;
-		const output = this.#currentRecipe.outputs.at(0).getItem();
+		const output = this.getCurrentRecipe().outputs.at(0).getItem();
 		const coreParamsY = y + lh * 1;
 		this.drawCoreParams(output, x, coreParamsY);
 		const traitsY = y + lh * 5;
@@ -2362,7 +2375,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	}
 	drawPrimaryOutputGold(x, y) {
 		const lh = this.lineHeight() - 4;
-		const output = this.#currentRecipe.outputs.at(0).getItem();
+		const output = this.getCurrentRecipe().outputs.at(0).getItem();
 		const tw = this.detailsQuarterTextWidth();
 		this.drawText("Resource:", x, y + lh * 1, tw);
 		const resourceY = y + lh * 2;
@@ -2372,7 +2385,7 @@ var Window_RecipeDetails = class Window_RecipeDetails extends Window_Base {
 	}
 	drawPrimaryOutputSdp(x, y) {
 		const lh = this.lineHeight() - 4;
-		const output = this.#currentRecipe.outputs.at(0).getItem();
+		const output = this.getCurrentRecipe().outputs.at(0).getItem();
 		const tw = this.detailsQuarterTextWidth();
 		this.drawText("Resource:", x, y + lh * 1, tw);
 		const resourceY = y + lh * 2;

--- a/chef-adventure/js/plugins/j/omni/ext/J-Omni-Monsters.js
+++ b/chef-adventure/js/plugins/j/omni/ext/J-Omni-Monsters.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.2.0 OMNI-MONSTER] Extends the Omnipedia with a Monsterpedia entry.
+ * [v1.2.1 OMNI-MONSTER] Extends the Omnipedia with a Monsterpedia entry.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -57,6 +57,11 @@
  * one per tag, in the order they appear on the note.
  * ============================================================================
  * CHANGELOG:
+ * - 1.2.1
+ *    The monsterpedia detail window no longer declares private members. A
+ *    window's constructor reaches initialize, and through it the drawing
+ *    hooks, before a derived class installs its own members- so anything
+ *    private was being touched on an object that did not yet have it.
  * - 1.2.0
  *    The monsterpedia lookup cache is no longer written to savefiles. It held
  *    the same observations as the saveables it is built from, keyed by enemy
@@ -145,7 +150,7 @@ J.OMNI.EXT.MONSTER = {};
 /**
 * The `metadata` associated with this plugin, such as version.
 */
-J.OMNI.EXT.MONSTER.Metadata = new J_OmniMonster_PluginMetadata("J-Omni-Monsterpedia", "1.2.0");
+J.OMNI.EXT.MONSTER.Metadata = new J_OmniMonster_PluginMetadata("J-Omni-Monsterpedia", "1.2.1");
 /**
 * A collection of all aliased methods for this plugin.
 */
@@ -667,27 +672,27 @@ var Window_MonsterpediaDetail = class extends Window_Base {
 	* The player's observations of the currently highlighted enemy.
 	* @type {MonsterpediaObservations|null}
 	*/
-	#currentObservations = null;
+	_currentObservations = null;
 	/**
 	* A cache of all sprites associated with enemies in the monsterpedia.
 	* @type {Map<number, Sprite_Enemy>}
 	*/
-	#battlerImageCache = new Map();
+	_battlerImageCache = new Map();
 	/**
 	* A cache of all sprites associated with base parameters.
 	* @type {Map<number, Sprite_Icon>}
 	*/
-	#baseParameterIconCache = new Map();
+	_baseParameterIconCache = new Map();
 	/**
 	* A cache of all sprites associated with sp parameters.
 	* @type {Map<number, Sprite_Icon>}
 	*/
-	#spParameterIconCache = new Map();
+	_spParameterIconCache = new Map();
 	/**
 	* A cache of all sprites associated with ex parameters.
 	* @type {Map<number, Sprite_Icon>}
 	*/
-	#exParameterIconCache = new Map();
+	_exParameterIconCache = new Map();
 	/**
 	* Constructor.
 	* @param {Rectangle} rect The rectangle that represents this window.
@@ -700,42 +705,42 @@ var Window_MonsterpediaDetail = class extends Window_Base {
 	* @returns {MonsterpediaObservations|null}
 	*/
 	getObservations() {
-		return this.#currentObservations;
+		return this._currentObservations;
 	}
 	/**
 	* Sets the current enemy observations for this window.
 	* @param {MonsterpediaObservations} observations The observations driving this step.
 	*/
 	setObservations(observations) {
-		this.#currentObservations = observations;
+		this._currentObservations = observations;
 	}
 	/**
 	* Gets the battler image cache.
 	* @returns {Map<number, Sprite_Enemy>}
 	*/
 	getEnemyImageCache() {
-		return this.#battlerImageCache;
+		return this._battlerImageCache;
 	}
 	/**
 	* Gets the b-parameter icon image cache.
 	* @returns {Map<number, Sprite_Icon>}
 	*/
 	getBaseParameterIconCache() {
-		return this.#baseParameterIconCache;
+		return this._baseParameterIconCache;
 	}
 	/**
 	* Gets the s-parameter icon image cache.
 	* @returns {Map<number, Sprite_Icon>}
 	*/
 	getSpParameterIconCache() {
-		return this.#spParameterIconCache;
+		return this._spParameterIconCache;
 	}
 	/**
 	* Gets the x-parameter icon image cache.
 	* @returns {Map<number, Sprite_Icon>}
 	*/
 	getExParameterIconCache() {
-		return this.#exParameterIconCache;
+		return this._exParameterIconCache;
 	}
 	/**
 	* Populates the sprite cache ahead of rendering.
@@ -1297,8 +1302,8 @@ var Window_MonsterpediaDetail = class extends Window_Base {
 		const { id } = observations;
 		const gameEnemy = $gameEnemies.enemy(id);
 		this.modFontSize(-4);
-		const taxonomy = this.#collectMonsterpediaTaxonomyRows(gameEnemy);
-		const taxonomyLineCount = this.#countMonsterpediaTaxonomyDrawLines(taxonomy);
+		const taxonomy = this.collectMonsterpediaTaxonomyRows(gameEnemy);
+		const taxonomyLineCount = this.countMonsterpediaTaxonomyDrawLines(taxonomy);
 		const damageTypeCount = 10;
 		const blockRowCount = Math.max(damageTypeCount, taxonomyLineCount);
 		const descriptionTop = this.height - this.lineHeight() * 6;
@@ -1311,7 +1316,7 @@ var Window_MonsterpediaDetail = class extends Window_Base {
 		const damageColumnX = taxonomyColumnX - damageColumnOffset;
 		const damageStartRow = 0;
 		const taxonomyStartRow = 0;
-		this.#drawMonsterpediaTaxonomySections(taxonomyColumnX, yTop, lh, taxonomyStartRow, observations, taxonomy);
+		this.drawMonsterpediaTaxonomySections(taxonomyColumnX, yTop, lh, taxonomyStartRow, observations, taxonomy);
 		const damageElementIds = [
 			1,
 			2,
@@ -1326,7 +1331,7 @@ var Window_MonsterpediaDetail = class extends Window_Base {
 		];
 		damageElementIds.forEach((elementId, index) => {
 			const row = damageStartRow + index;
-			this.#drawMonsterpediaDamageElementRow(damageColumnX, yTop, lh, row, observations, elementId);
+			this.drawMonsterpediaDamageElementRow(damageColumnX, yTop, lh, row, observations, elementId);
 		});
 	}
 	/**
@@ -1338,7 +1343,7 @@ var Window_MonsterpediaDetail = class extends Window_Base {
 	*   tool: {elementId: number, label: string, rate: number}[]
 	* }}
 	*/
-	#collectMonsterpediaTaxonomyRows(gameEnemy) {
+	collectMonsterpediaTaxonomyRows(gameEnemy) {
 		const names = $dataSystem.elements;
 		const vs = [];
 		const xList = [];
@@ -1388,7 +1393,7 @@ var Window_MonsterpediaDetail = class extends Window_Base {
 	* @param {{ vs: object[], x: object[], tool: object[] }} taxonomy The grouped taxonomy rows.
 	* @returns {number}
 	*/
-	#countMonsterpediaTaxonomyDrawLines(taxonomy) {
+	countMonsterpediaTaxonomyDrawLines(taxonomy) {
 		let lines = 0;
 		if (taxonomy.vs.length > 0) {
 			lines += 1 + taxonomy.vs.length;
@@ -1411,11 +1416,11 @@ var Window_MonsterpediaDetail = class extends Window_Base {
 	* @param {{ vs: object[], x: object[], tool: object[] }} taxonomy The grouped taxonomy rows.
 	* @returns {number} The next row index after drawing taxonomy content.
 	*/
-	#drawMonsterpediaTaxonomySections(x, y, lh, row, observations, taxonomy) {
+	drawMonsterpediaTaxonomySections(x, y, lh, row, observations, taxonomy) {
 		let r = row;
-		r = this.#drawMonsterpediaTaxonomyBucket(x, y, lh, r, observations, taxonomy.vs, "Family");
-		r = this.#drawMonsterpediaTaxonomyBucket(x, y, lh, r, observations, taxonomy.x, "Traits");
-		r = this.#drawMonsterpediaTaxonomyBucket(x, y, lh, r, observations, taxonomy.tool, "Tools");
+		r = this.drawMonsterpediaTaxonomyBucket(x, y, lh, r, observations, taxonomy.vs, "Family");
+		r = this.drawMonsterpediaTaxonomyBucket(x, y, lh, r, observations, taxonomy.x, "Traits");
+		r = this.drawMonsterpediaTaxonomyBucket(x, y, lh, r, observations, taxonomy.tool, "Tools");
 		return r;
 	}
 	/**
@@ -1429,7 +1434,7 @@ var Window_MonsterpediaDetail = class extends Window_Base {
 	* @param {string} headerText The section title.
 	* @returns {number} The next row index after this bucket.
 	*/
-	#drawMonsterpediaTaxonomyBucket(x, y, lh, row, observations, rows, headerText) {
+	drawMonsterpediaTaxonomyBucket(x, y, lh, row, observations, rows, headerText) {
 		if (rows.length === 0) return row;
 		let cursor = row;
 		this.resetFontSettings();
@@ -1441,7 +1446,7 @@ var Window_MonsterpediaDetail = class extends Window_Base {
 		cursor += 1;
 		rows.forEach((entry) => {
 			const { elementId, label, rate } = entry;
-			this.#drawMonsterpediaTaxonomyElementRow(x, y, lh, cursor, observations, elementId, label, rate);
+			this.drawMonsterpediaTaxonomyElementRow(x, y, lh, cursor, observations, elementId, label, rate);
 			cursor += 1;
 		});
 		return cursor;
@@ -1457,7 +1462,7 @@ var Window_MonsterpediaDetail = class extends Window_Base {
 	* @param {string} label The display label (prefix stripped).
 	* @param {number} rate The rounded percent rate.
 	*/
-	#drawMonsterpediaTaxonomyElementRow(x, y, lh, row, observations, elementId, label, rate) {
+	drawMonsterpediaTaxonomyElementRow(x, y, lh, row, observations, elementId, label, rate) {
 		this.resetFontSettings();
 		this.modFontSize(-4);
 		const elementIcon = IconManager.element(elementId);
@@ -1487,7 +1492,7 @@ var Window_MonsterpediaDetail = class extends Window_Base {
 	* @param {MonsterpediaObservations} observations The active observations.
 	* @param {number} elementId The database element id.
 	*/
-	#drawMonsterpediaDamageElementRow(x, y, lh, row, observations, elementId) {
+	drawMonsterpediaDamageElementRow(x, y, lh, row, observations, elementId) {
 		this.resetFontSettings();
 		this.modFontSize(-4);
 		this.changeTextColor(ColorManager.normalColor());

--- a/chef-adventure/js/plugins/j/omni/ext/J-Omni-Questopedia.js
+++ b/chef-adventure/js/plugins/j/omni/ext/J-Omni-Questopedia.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.2.0 OMNI-QUEST] Extends the Omnipedia with a Questopedia entry.
+ * [v1.2.1 OMNI-QUEST] Extends the Omnipedia with a Questopedia entry.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -138,6 +138,11 @@
  * This choice is only shown while objective 2 of that quest is completed.
  * ============================================================================
  * CHANGELOG:
+ * - 1.2.1
+ *    The questopedia description window no longer declares private members. A
+ *    window's constructor reaches initialize, and through it the drawing
+ *    hooks, before a derived class installs its own members- so anything
+ *    private was being touched on an object that did not yet have it.
  * - 1.2.0
  *    The questopedia lookup cache is no longer written to savefiles. It held
  *    the same entries as the saveables it is built from, keyed for lookup,
@@ -2396,7 +2401,7 @@ J.OMNI.EXT.QUEST = {};
 /**
 * The metadata associated with this plugin.
 */
-J.OMNI.EXT.QUEST.Metadata = new J_QUEST_PluginMetadata("J-Omni-Questopedia", "1.2.0");
+J.OMNI.EXT.QUEST.Metadata = new J_QUEST_PluginMetadata("J-Omni-Questopedia", "1.2.1");
 /**
 * A collection of all aliased methods for this plugin.
 */
@@ -2594,7 +2599,7 @@ var Window_QuestopediaDescription = class extends Window_Base {
 	* The current selected quest in the quest list window.
 	* @type {TrackedOmniQuest}
 	*/
-	#currentQuest = null;
+	_currentQuest = null;
 	/**
 	* Constructor.
 	* @param {Rectangle} rect The rectangle that represents this window.
@@ -2607,14 +2612,14 @@ var Window_QuestopediaDescription = class extends Window_Base {
 	* @returns {TrackedOmniQuest}
 	*/
 	getCurrentQuest() {
-		return this.#currentQuest;
+		return this._currentQuest;
 	}
 	/**
 	* Sets the quest currently being displayed.
 	* @param {TrackedOmniQuest} quest The quest to display data for.
 	*/
 	setCurrentQuest(quest) {
-		this.#currentQuest = quest;
+		this._currentQuest = quest;
 	}
 	drawContent() {
 		const quest = this.getCurrentQuest();

--- a/chef-adventure/js/plugins/j/sdp/J-SDP.js
+++ b/chef-adventure/js/plugins/j/sdp/J-SDP.js
@@ -2,7 +2,7 @@
  
 /*:
  * @target MZ
- * @plugindesc [v3.1.0 SDP] Enables the SDP system, aka Stat Distribution Panels.
+ * @plugindesc [v3.2.0 SDP] Enables the SDP system, aka Stat Distribution Panels.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -364,6 +364,18 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 3.2.0
+ *    Unspent points now appear on each party member's cell in the main menu,
+ *    beside their level and the distance to the next one. A currency nobody is
+ *    reminded of is a currency nobody spends, and the points are otherwise
+ *    invisible until the player already went looking for them.
+ *    This is drawn through the extension hook J-CMS reserves for exactly this,
+ *    and does nothing at all when that plugin is not installed.
+ *    The family strip, header, mastery, and parameter list windows no longer
+ *    declare private members. A window's constructor reaches initialize, and
+ *    through it the drawing hooks, before a derived class installs its own
+ *    members- so anything private was being touched on an object that did not
+ *    yet have it.
  * - 3.1.0
  *    Routed the _sdp namespace into its own save section, so panel investment
  *    and mastery land in systems/sdp.json rather than in the system blob.
@@ -2559,7 +2571,7 @@ J.SDP = {};
 /**
 * The metadata associated with this plugin.
 */
-J.SDP.Metadata = new J_SdpPluginMetadata("J-SDP", "3.1.0");
+J.SDP.Metadata = new J_SdpPluginMetadata("J-SDP", "3.2.0");
 /**
 * A collection of all aliased methods for this plugin.
 */
@@ -2579,7 +2591,8 @@ J.SDP.Aliased = {
 	Scene_Boot: new Map(),
 	Scene_Map: new Map(),
 	Scene_Menu: new Map(),
-	Window_MenuCommand: new Map()
+	Window_MenuCommand: new Map(),
+	Window_MenuStatus: new Map()
 };
 /**
 * All regular expressions used by this plugin.
@@ -3635,6 +3648,58 @@ Window_MenuCommand.prototype.canAddSdpCommand = function() {
 };
 
 //#endregion
+//#region src/plugins/sdp/core/windows/Window_MenuStatus.js
+/**
+* J-CMS reserves a block at the foot of each party member's menu cell for whatever the plugins
+* layered on top of it have to say. Unspent node points are the clearest thing this plugin can
+* contribute there: they are a currency the player is holding rather than spending, and a currency
+* nobody is reminded of is one nobody spends.
+*
+* The check is for J-CMS itself rather than for the method, because this is the one honestly
+* optional dependency in play- the main menu redesign may simply not be installed, in which case
+* there is no cell to draw into and nothing here should exist.
+*/
+if (J.CMS) {
+	/**
+	* Extends {@link #drawExtensionData}.<br/>
+	* Also reports how many node points this actor is holding unspent.
+	*
+	* Draws beneath whatever the original returned rather than at the y it was handed, so that this
+	* plugin claims a row of its own without needing to know whether anything else already claimed
+	* one above it.
+	* @param {Game_Actor} actor The actor being described.
+	* @param {number} x The left edge of the space available.
+	* @param {number} y The top of the space available.
+	* @param {number} width The width available.
+	* @returns {number}
+	*/
+	J.SDP.Aliased.Window_MenuStatus.set("drawExtensionData", Window_MenuStatus.prototype.drawExtensionData);
+	Window_MenuStatus.prototype.drawExtensionData = function(actor, x, y, width) {
+		const nextY = J.SDP.Aliased.Window_MenuStatus.get("drawExtensionData").call(this, actor, x, y, width);
+		this.drawSdpPoints(actor, x, nextY, width);
+		return nextY + this.lineHeight();
+	};
+	/**
+	* Draws how many node points this actor has available to spend.
+	*
+	* Drawn even at zero rather than hidden when empty. A row that appears only sometimes teaches the
+	* player nothing about where to look for it, and a standing zero is what makes a later non-zero
+	* legible as a change worth acting on.
+	* @param {Game_Actor} actor The actor whose points are being reported.
+	* @param {number} x The left edge of the row.
+	* @param {number} y The top of the row.
+	* @param {number} width The width available to the row.
+	*/
+	Window_MenuStatus.prototype.drawSdpPoints = function(actor, x, y, width) {
+		const points = actor.getSdpPoints();
+		this.drawIcon(J.SDP.Metadata.sdpIconIndex, x, y);
+		const valueX = x + ImageManager.standardIconWidth + 8;
+		this.resetTextColor();
+		this.drawText(`${points}`, valueX, y, width - (valueX - x), "left");
+	};
+}
+
+//#endregion
 //#region src/plugins/sdp/core/managers/SdpFamilyFilter.js
 /**
 * Family-filter symbols and helpers for the SDP panel list.
@@ -4020,20 +4085,27 @@ var Window_SdpHeader = class extends Window_Base {
 	/**
 	* @type {StatDistributionPanel|null}
 	*/
-	#panel = null;
+	_panel = null;
 	/**
 	* Binds the hovered panel to this header.
 	* @param {StatDistributionPanel|null} panel The hovered panel.
 	*/
 	setPanel(panel) {
-		this.#panel = panel;
+		this._panel = panel;
+	}
+	/**
+	* The panel currently bound to this header.
+	* @returns {StatDistributionPanel|null}
+	*/
+	panel() {
+		return this._panel;
 	}
 	/**
 	* Implements {@link Window_Base.drawContent}.<br/>
 	* Renders the single-line summary for the hovered panel.
 	*/
 	drawContent() {
-		const panel = this.#panel;
+		const panel = this.panel();
 		if (!panel) {
 			return;
 		}
@@ -4111,10 +4183,10 @@ var Window_SdpParameterList = class extends Window_Command {
 	*/
 	buildCommands() {
 		if (this.panelParameters.length === 0) return [];
-		const commands = this.panelParameters.map(this.#buildPanelParameterCommand, this);
+		const commands = this.panelParameters.map(this.buildPanelParameterCommand, this);
 		return commands;
 	}
-	#buildPanelParameterCommand(panelParameter) {
+	buildPanelParameterCommand(panelParameter) {
 		const { parameterKey, isCore } = panelParameter;
 		const definition = ParameterRegistry.get(parameterKey);
 		const colorIndex = isCore ? 14 : 0;
@@ -4123,12 +4195,12 @@ var Window_SdpParameterList = class extends Window_Command {
 		const paramValue = this.currentActor.parameter(parameterKey);
 		const paramDescription = definition ? definition.description() : [String.empty];
 		const prettyValue = definition ? definition.prettyValue(paramValue, false, this.currentActor) : Math.trunc(paramValue).toString();
-		const { modifierColorIndex, modifierText } = this.#determineModifierData(panelParameter);
+		const { modifierColorIndex, modifierText } = this.determineModifierData(panelParameter);
 		const commandName = `${paramName} ( ${prettyValue} )`;
 		const command = new WindowCommandBuilder(commandName).setSymbol(parameterKey).addTextLines(paramDescription).setIconIndex(paramIcon).setColorIndex(colorIndex).setRightText(modifierText).setRightColorIndex(modifierColorIndex).setExtensionData(panelParameter).build();
 		return command;
 	}
-	#determineModifierData(panelParameter) {
+	determineModifierData(panelParameter) {
 		const calculateAfterRankUpValue = (paramValue, modifier, isFlat) => {
 			return isFlat ? Number((paramValue + modifier).toFixed(2)) : paramValue + paramValue * (modifier / 100);
 		};
@@ -4317,20 +4389,27 @@ var Window_SdpMastery = class extends Window_Base {
 	/**
 	* @type {StatDistributionPanel|null}
 	*/
-	#panel = null;
+	_panel = null;
 	/**
 	* Binds the hovered panel to this mastery strip.
 	* @param {StatDistributionPanel|null} panel The hovered panel.
 	*/
 	setPanel(panel) {
-		this.#panel = panel;
+		this._panel = panel;
+	}
+	/**
+	* The panel currently bound to this mastery strip.
+	* @returns {StatDistributionPanel|null}
+	*/
+	panel() {
+		return this._panel;
 	}
 	/**
 	* Implements {@link Window_Base.drawContent}.<br>
 	* Renders subgroup mastery enrollment for the hovered panel.
 	*/
 	drawContent() {
-		const panel = this.#panel;
+		const panel = this.panel();
 		if (!panel) {
 			return;
 		}
@@ -4900,7 +4979,7 @@ var Window_SdpFamilyStrip = class extends Window_Base {
 	* Active family-filter key ({@link SdpFamilyFilter.ALL}, {@link SdpFamilyFilter.UNKNOWN}, or a family key).
 	* @type {string}
 	*/
-	#filterKey = SdpFamilyFilter.ALL;
+	_filterKey = SdpFamilyFilter.ALL;
 	/**
 	* @param {Rectangle} rect The dimensions of the window.
 	*/
@@ -4913,15 +4992,22 @@ var Window_SdpFamilyStrip = class extends Window_Base {
 	* @param {string} filterKey The filter key driving this step.
 	*/
 	setFilterKey(filterKey) {
-		this.#filterKey = filterKey;
+		this._filterKey = filterKey;
 		this.refresh();
+	}
+	/**
+	* The family filter currently driving this strip.
+	* @returns {string}
+	*/
+	filterKey() {
+		return this._filterKey;
 	}
 	/**
 	* Implements {@link Window_Base.drawContent}.<br/>
 	* Renders the current family filter label and icon.
 	*/
 	drawContent() {
-		const filterKey = this.#filterKey;
+		const filterKey = this.filterKey();
 		const label = SdpFamilyFilter.displayNameForFilterKey(filterKey);
 		const iconIndex = SdpFamilyFilter.iconIndexForFilterKey(filterKey);
 		const iconPad = 4;


### PR DESCRIPTION
Mirrors the built ships from [rmmz-plugins#72](https://github.com/je-can-code/rmmz-plugins/pull/72). Nine plugins, no data or map changes.

## What changes in-game

**The main menu's party display.** Each member's cell is now a character card rather than a data row:

- Name heading the cell with their class beneath it, upper-cased and tinted.
- Map sprite standing beside the portrait — the face is who they are in a conversation, the sprite is who you've actually been looking at all game.
- Level and remaining experience sharing a row, divided by a mark set in the space between them.
- Resources as segmented gauges spanning the cell, one notch per twenty, marked by icon rather than by `LP`/`MP`/`TP` and trailed by their values.
- Afflicting states by icon, with an actor suffering none saying so outright rather than leaving a blank row.
- Every equipment slot, with empty ones named and dimmed rather than omitted.
- Unspent node points beside level and experience.

**Two repairs.**

- The party display was overrunning the currency strip by the height of the control legend — sixty pixels hidden underneath the very window that caused them.
- Each cell was being tinted behind its contents, which is the marking that shows where a cursor is. Nothing selects a party member here, so it advertised an interaction that does not exist.

## What changes under the hood

Eight ships are converted off private class members. A class whose base constructor calls a hook the subclass overrides is branded only after `super()` returns, so anything private was being touched on an object that did not have it yet. Save decode had the same problem from the other direction and was already gated; this is the half that detonates during boot, and it is why `J-ABS-Boss` was throwing.

## Note on plugin parameters

Two strings are still configured in `js/plugins.js` and unaffected by this PR:

- The main menu's command help text still reads "this character", which points at a referent the menu never identifies. The plugin defaults are updated; the saved values are not.
- `sdpPointsDisplayName` is `"SDP"` while the same plugin's multiplier already reads "Node Points UP".
