### PR TITLE
Sync rebuilt plugin ships, plus weapon data

### DIFF
--- a/chef-adventure/data/Weapons.json
+++ b/chef-adventure/data/Weapons.json
@@ -1,183 +1,6808 @@
 [
-null,
-{"id":1,"name":"Tarnished Sword","note":"<skillId:1>\n<offhandSkillId:4>\n<maxRefineCount:2>\n<maxRefinedTraits:2>\n<thisHit:10>\n<thisCri:2>","description":"A dirty and dark-bladed sword.\nIt might've had some magical properties at some point, but definitely doesn't now.","iconIndex":545,"traits":[{"code":31,"dataId":1,"value":0}],"etypeId":1,"params":[0,0,15,0,0,0,0,0],"price":100,"animationId":6,"wtypeId":1},
-{"id":2,"name":"Greyed Sword","note":"<skillId:1>\n<offhandSkillId:4>\n<maxRefineCount:5>\n<maxRefinedTraits:3>\n<thisHit:20>\n<thisCri:8>","description":"A darkened blade finally makes its appearance!\nImbued with \\element[9].","iconIndex":1713,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":9,"value":0}],"etypeId":1,"params":[0,0,30,0,0,0,0,0],"price":1000,"animationId":6,"wtypeId":1},
-{"id":3,"name":"Dark Slash","note":"<skillId:1>\n<offhandSkillId:4>\n<maxRefineCount:8>\n<maxRefinedTraits:4>\n<thisHit:65>\n<thisCri:15>","description":"When forging swords with Noire, apparently they become rather sinister-looking.\nImbued with \\element[9], may slay causing \\State[1](1%) on-hit.","iconIndex":578,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":9,"value":0},{"code":32,"dataId":1,"value":0.01}],"etypeId":1,"params":[0,0,60,0,0,0,0,0],"price":10000,"animationId":6,"wtypeId":1},
-{"id":4,"name":"Nocturnal Blade","note":"<skillId:1>\n<offhandSkillId:4>\n<maxRefineCount:12>\n<maxRefinedTraits:5>\n<thisHit:90>\n<thisCri:30>","description":"Further upgrading the quality of Noire is starting to make the blade look like midnight.\nImbued with \\element[9], may slay causing \\State[1](2%) on-hit.","iconIndex":1721,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":9,"value":0},{"code":32,"dataId":1,"value":0.02}],"etypeId":1,"params":[0,0,90,0,0,0,0,0],"price":50000,"animationId":6,"wtypeId":1},
-{"id":5,"name":"Ecliptic Render","note":"<skillId:1>\n<offhandSkillId:4>\n<maxRefineCount:18>\n<maxRefinedTraits:7>\n<thisHit:105>\n<thisCri:50>","description":"The Noire has drunk so deeply that the blade now swallows what little light finds it.\nImbued with \\element[9], may slay causing \\State[1](3%) on-hit.","iconIndex":1622,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":9,"value":0},{"code":32,"dataId":1,"value":0.03}],"etypeId":1,"params":[0,0,135,0,0,0,0,0],"price":175000,"animationId":6,"wtypeId":1},
-{"id":6,"name":"Lunar Vengeance","note":"<skillId:1>\n<offhandSkillId:4>\n<maxRefineCount:25>\n<maxRefinedTraits:10>\n<thisHit:125>\n<thisCri:80>","description":"The darkness in its most natural habitat, the dark side of the moon.\nImbued with \\element[9], may slay causing \\State[1](4%) on-hit.","iconIndex":1643,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":9,"value":0},{"code":32,"dataId":1,"value":0.04}],"etypeId":1,"params":[0,0,190,0,0,0,0,0],"price":500000,"animationId":6,"wtypeId":1},
-{"id":7,"name":"\"Light Thrust\"","note":"<skillId:1>\n<offhandSkillId:4>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:75>\n<thisCri:10>","description":"⭐ An unusually glowy blade for a \"sword in the stone\" type of weapon.\nImbued with \\element[8], may purge causing \\State[1](2%) on-hit.","iconIndex":560,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":8,"value":0},{"code":32,"dataId":1,"value":0.02}],"etypeId":1,"params":[0,0,50,0,0,0,0,0],"price":0,"animationId":6,"wtypeId":1},
-{"id":8,"name":"\"Sacred Spine\"","note":"<skillId:1>\n<offhandSkillId:4>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:140>\n<thisCri:15>","description":"⭐⭐ The glow of the blade appears to have sharpened the blade to a fine point.\nImbued with \\element[8], may purge causing \\State[1](4%) on-hit.","iconIndex":562,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":8,"value":0},{"code":32,"dataId":1,"value":0.04}],"etypeId":1,"params":[0,0,100,0,0,0,0,0],"price":0,"animationId":6,"wtypeId":1},
-{"id":9,"name":"\"Claidheamh Soluis\"","note":"<skillId:1>\n<offhandSkillId:4>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:200>\n<thisCri:25>","description":"⭐⭐⭐ An ascended blade of pure energy, renowned for cleaving foes in twain.\nImbued with \\element[8], may purge causing \\State[1](6%) on-hit.","iconIndex":1638,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":8,"value":0},{"code":32,"dataId":1,"value":0.06}],"etypeId":1,"params":[0,0,225,0,0,0,0,0],"price":0,"animationId":6,"wtypeId":1},
-{"id":10,"name":"\"The Corona\"","note":"<skillId:1>\n<offhandSkillId:4>\n<notRefinementMaterial>\n<thisHit:250>\n<thisCri:150>","description":"\"Dark swallows the light; heaven opens, hell yawns wide;\nand the crown remains.\"","iconIndex":1777,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":10,"value":0}],"etypeId":1,"params":[0,0,380,0,0,0,0,0],"price":0,"animationId":6,"wtypeId":1},
-{"id":11,"name":"Whistling Claymore","note":"<skillId:11>\n<offhandSkillId:14>\n<speedBoost:-15>\n<maxRefineCount:4>\n<maxRefinedTraits:4>\n<thisHit:40>\n<thisCri:15>","description":"It is very light- for a crappy claymore.\nWielded in both hands.","iconIndex":1644,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,50,0,0,0,0,0],"price":100,"animationId":6,"wtypeId":2},
-{"id":12,"name":"Gusty Slasher","note":"<skillId:11>\n<offhandSkillId:14>\n<speedBoost:-15>\n<maxRefineCount:10>\n<maxRefinedTraits:6>\n<thisHit:60>\n<thisCri:30>","description":"Forged with a nice chunk of verte, this sizeable slasher was born.\nImbued with \\element[6], wielded in both hands.","iconIndex":513,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":6,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,90,0,0,0,0,0],"price":1000,"animationId":6,"wtypeId":2},
-{"id":13,"name":"Cyclone Sword","note":"<skillId:11>\n<offhandSkillId:14>\n<speedBoost:-15>\n<maxRefineCount:16>\n<maxRefinedTraits:8>\n<thisHit:100>\n<thisCri:40>","description":"The power of the gale wraps this massive sword like a soft and delicate blanket.\nImbued with \\element[6], may apply \\State[11](25%) on-hit, wielded in both hands.","iconIndex":514,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":6,"value":0},{"code":32,"dataId":11,"value":0.25},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,150,0,0,0,0,0],"price":10000,"animationId":6,"wtypeId":2},
-{"id":14,"name":"Mountaintop Chopper","note":"<skillId:11>\n<offhandSkillId:14>\n<speedBoost:-15>\n<maxRefineCount:24>\n<maxRefinedTraits:10>\n<thisHit:170>\n<thisCri:60>","description":"Empowered with the blessing of the mountain winds, you still aren't very fast while holding this.\nImbued with \\element[6], may apply \\State[11](50%) on-hit, wielded in both hands.","iconIndex":516,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":6,"value":0},{"code":32,"dataId":11,"value":0.5},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,210,0,0,0,0,0],"price":50000,"animationId":6,"wtypeId":2},
-{"id":15,"name":"Hurricane Hacker","note":"<skillId:11>\n<offhandSkillId:14>\n<speedBoost:-15>\n<maxRefineCount:36>\n<maxRefinedTraits:14>\n<thisHit:250>\n<thisCri:100>","description":"A mighty hurricane RAGES inside this vicious claymore, theoretically.\nImbued with \\element[6], may apply \\State[11](75%) on-hit, wielded in both hands.","iconIndex":1556,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":6,"value":0},{"code":32,"dataId":11,"value":0.75},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,280,0,0,0,0,0],"price":175000,"animationId":6,"wtypeId":2},
-{"id":16,"name":"Sundering Cleaver","note":"<skillId:11>\n<offhandSkillId:14>\n<speedBoost:-15>\n<maxRefineCount:50>\n<maxRefinedTraits:20>\n<thisHit:320>\n<thisCri:140>","description":"An enormous claymore whose every slash cleaves the skies (and your foes defenses) asunder.\nImbued with \\element[6], applies \\State[11] on-hit, wielded in both hands.","iconIndex":1653,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":6,"value":0},{"code":32,"dataId":11,"value":1},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,350,0,0,0,0,0],"price":500000,"animationId":6,"wtypeId":2},
-{"id":17,"name":"\"Colossus\"","note":"<skillId:11>\n<offhandSkillId:14>\n<speedBoost:-15>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:100>\n<thisCri:30>","description":"⭐ Are you trying to compensate by wielding this monstrously large chunk of rock?\nImbued with \\element[7], may apply \\State[12](50%) on-hit, wielded in both hands.","iconIndex":546,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":7,"value":0},{"code":32,"dataId":12,"value":0.5},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,120,0,0,0,0,0],"price":0,"animationId":6,"wtypeId":2},
-{"id":18,"name":"\"Juggernaut\"","note":"<skillId:11>\n<offhandSkillId:14>\n<speedBoost:-15>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:200>\n<thisCri:80>","description":"⭐⭐ A colossal weapon reinforced with the finest ores.\nImbued with \\element[7], applies \\State[12] on-hit, wielded in both hands.","iconIndex":1646,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":7,"value":0},{"code":32,"dataId":12,"value":1},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,250,0,0,0,0,0],"price":0,"animationId":6,"wtypeId":2},
-{"id":19,"name":"\"Lævateinn\"","note":"<skillId:11>\n<offhandSkillId:14>\n<speedBoost:-15>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:380>\n<thisCri:160>","description":"⭐⭐⭐ An ascended blade of dragon-slaying might, able to take down any reptile around!\nImbued with \\element[7], applies \\State[12] on-hit, wielded in both hands.","iconIndex":1641,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":7,"value":0},{"code":31,"dataId":12,"value":0},{"code":32,"dataId":12,"value":1},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,550,0,0,0,0,0],"price":0,"animationId":6,"wtypeId":2},
-{"id":20,"name":"\"Aeolian\"","note":"<skillId:11>\n<offhandSkillId:14>\n<speedBoost:-15>\n<notRefinementMaterial>\n<thisHit:450>\n<thisCri:250>","description":"The gale cannot be stopped, the mountain cannot be moved, and yet the canyon exists.\nWielded in both hands.","iconIndex":1621,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":10,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,720,0,0,0,0,0],"price":0,"animationId":6,"wtypeId":2},
-{"id":21,"name":"Rain Edge","note":"<skillId:21>\n<speedBoost:10>\n<maxRefineCount:2>\n<maxRefinedTraits:2>\n<thisHit:15>\n<thisCri:4>\n<thisGrd:12>","description":"A blade that has taken on a much lighter form, and looks pretty slick now.\nImbued with \"Liquid\", may apply \\State[10](10%) on-hit, designed to be dual-wielded with another weapon.","iconIndex":592,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":5,"value":0},{"code":32,"dataId":10,"value":0.1},{"code":55,"dataId":1,"value":1}],"etypeId":1,"params":[0,0,10,0,0,0,0,0],"price":100,"animationId":6,"wtypeId":3},
-{"id":22,"name":"Blaze Edge","note":"<skillId:21>\n<speedBoost:12>\n<maxRefineCount:5>\n<maxRefinedTraits:3>\n<thisHit:18>\n<thisCri:12>\n<thisGrd:15>","description":"A blade that is too hot to touch! It seems forging with rouge has a heat-like elemental effect.\nImbued with \"Heat\", may apply \\State[9](10%) on-hit, designed to be dual-wielded with another weapon.","iconIndex":528,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":4,"value":0},{"code":32,"dataId":9,"value":0.1},{"code":55,"dataId":1,"value":1}],"etypeId":1,"params":[0,0,25,0,0,0,0,0],"price":2500,"animationId":6,"wtypeId":3},
-{"id":23,"name":"Vulcan Edge","note":"<skillId:21>\n<speedBoost:15>\n<maxRefineCount:8>\n<maxRefinedTraits:4>\n<thisHit:25>\n<thisCri:22>\n<thisGrd:20>","description":"A ruthless blade powered by the flames of the finest Rouge.\nImbued with \"Heat\", may apply \\State[9](20%) on-hit, designed to be dual-wielded with another weapon.","iconIndex":529,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":4,"value":0},{"code":32,"dataId":9,"value":0.2},{"code":55,"dataId":1,"value":1}],"etypeId":1,"params":[0,0,45,0,0,0,0,0],"price":250000,"animationId":6,"wtypeId":3},
-{"id":24,"name":"Torrent Edge","note":"<skillId:21>\n<speedBoost:18>\n<maxRefineCount:12>\n<maxRefinedTraits:5>\n<thisHit:55>\n<thisCri:24>\n<thisGrd:35>","description":"A gorgeous edge that is capable of a torrent of strikes in no time.\nImbued with \"Liquid\", may apply \\State[10](20%) on-hit, designed to be dual-wielded with another weapon.","iconIndex":593,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":5,"value":0},{"code":32,"dataId":10,"value":0.2},{"code":55,"dataId":1,"value":1}],"etypeId":1,"params":[0,0,65,0,0,0,0,0],"price":500000,"animationId":6,"wtypeId":3},
-{"id":25,"name":"Inferno Edge","note":"<skillId:21>\n<speedBoost:22>\n<maxRefineCount:18>\n<maxRefinedTraits:7>\n<thisHit:60>\n<thisCri:38>\n<thisGrd:38>","description":"A blade whose edge never cools, forged from the most volatile rouge obtainable.\nImbued with \"Heat\", may apply \\State[9](25%) on-hit, designed to be dual-wielded with another weapon.","iconIndex":530,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":4,"value":0},{"code":32,"dataId":9,"value":0.25},{"code":55,"dataId":1,"value":1}],"etypeId":1,"params":[0,0,85,0,0,0,0,0],"price":750000,"animationId":6,"wtypeId":3},
-{"id":26,"name":"Maelstrom Edge","note":"<skillId:21>\n<speedBoost:26>\n<maxRefineCount:25>\n<maxRefinedTraits:10>\n<thisHit:85>\n<thisCri:40>\n<thisGrd:52>","description":"A blade that moves like a current with a will of its own, pulling every strike into the next.\nImbued with \"Liquid\", may apply \\State[10](25%) on-hit, designed to be dual-wielded with another weapon.","iconIndex":594,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":5,"value":0},{"code":32,"dataId":10,"value":0.25},{"code":55,"dataId":1,"value":1}],"etypeId":1,"params":[0,0,105,0,0,0,0,0],"price":999999,"animationId":6,"wtypeId":3},
-{"id":27,"name":"\"Agility\"","note":"<skillId:21>\n<speedBoost:20>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:30>\n<thisGrd:30>","description":"⭐ Supposedly the embodiment of agility, and does indeed improve hit and parry chances.\nDesigned to be dual-wielded with another weapon.","iconIndex":1718,"traits":[{"code":31,"dataId":1,"value":0},{"code":55,"dataId":1,"value":1}],"etypeId":1,"params":[0,0,40,0,0,0,10,0],"price":0,"animationId":6,"wtypeId":3},
-{"id":28,"name":"\"Swiftness\"","note":"<skillId:21>\n<speedBoost:25>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:60>\n<thisGrd:60>","description":"⭐⭐ A masterfully refined upgrade to agility, this blade truly is swiftness incarnate.\nDesigned to be dual-wielded with another weapon.","iconIndex":1632,"traits":[{"code":31,"dataId":1,"value":0},{"code":55,"dataId":1,"value":1}],"etypeId":1,"params":[0,0,75,0,0,0,20,0],"price":0,"animationId":6,"wtypeId":3},
-{"id":29,"name":"\"Hrunting\"","note":"<skillId:21>\n<speedBoost:30>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:100>\n<thisGrd:100>","description":"⭐⭐⭐ An ascended blade that drips with a lethal poison that will seal healing of any kind.\nMay apply \\State[14](20%) on-hit, designed to be dual-wielded with another weapon.","iconIndex":1654,"traits":[{"code":31,"dataId":1,"value":0},{"code":32,"dataId":14,"value":0.2},{"code":55,"dataId":1,"value":1}],"etypeId":1,"params":[0,0,150,0,0,0,0,0],"price":0,"animationId":6,"wtypeId":3},
-{"id":30,"name":"\"Gemini\"","note":"<skillId:21>\n<speedBoost:35>\n<notRefinementMaterial>\n<thisHit:150>\n<thisCri:90>\n<thisGrd:90>","description":"Heat and current, quenched into one steel that promptly decided to be two.\nAlways found as a pair, and always wielded as one.","iconIndex":609,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":10,"value":0},{"code":55,"dataId":1,"value":1}],"etypeId":1,"params":[0,0,210,0,0,0,0,0],"price":0,"animationId":6,"wtypeId":3},
-{"id":31,"name":"Poker","note":"<skillId:31>\n<offhandSkillId:34>\n<speedBoost:5>\n<maxRefineCount:4>\n<maxRefinedTraits:4>\n<cdmBuffPlus:[50]>\n<thisHit:30>\n<thisCri:6>","description":"While it is technically a spear-class weapon, this is still just a fucking stick.\nWielded in both hands.","iconIndex":791,"traits":[{"code":31,"dataId":2,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,5,0,0,0,10,0],"price":100,"animationId":11,"wtypeId":4},
-{"id":32,"name":"Piercer","note":"<skillId:31>\n<offhandSkillId:34>\n<speedBoost:5>\n<maxRefineCount:10>\n<maxRefinedTraits:6>\n<cdmBuffPlus:[75]>\n<thisHit:50>\n<thisCri:12>","description":"Your standard-issue soldier's iron spear.\nWielded in both hands.","iconIndex":107,"traits":[{"code":31,"dataId":2,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,10,0,0,0,25,0],"price":1000,"animationId":11,"wtypeId":4},
-{"id":33,"name":"Perforator","note":"<skillId:31>\n<offhandSkillId:34>\n<speedBoost:10>\n<maxRefineCount:16>\n<maxRefinedTraits:8>\n<cdmBuffPlus:[125]>\n<thisHit:70>\n<thisCri:25>","description":"Punches clean holes through things that would rather remain whole.\nWielded in both hands.","iconIndex":515,"traits":[{"code":31,"dataId":2,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,40,0,0,0,75,0],"price":25000,"animationId":11,"wtypeId":4},
-{"id":34,"name":"Transfixer","note":"<skillId:31>\n<offhandSkillId:34>\n<speedBoost:10>\n<maxRefineCount:24>\n<maxRefinedTraits:10>\n<cdmBuffPlus:[150]>\n<thisHit:90>\n<thisCri:30>","description":"Long enough to go all the way through, and it usually does.\nWielded in both hands, may apply \\State[15](5%) on-hit.","iconIndex":435,"traits":[{"code":31,"dataId":2,"value":0},{"code":32,"dataId":15,"value":0.05},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,100,0,0,0,150,0],"price":100000,"animationId":11,"wtypeId":4},
-{"id":35,"name":"Eviscerator","note":"<skillId:31>\n<offhandSkillId:34>\n<speedBoost:15>\n<maxRefineCount:36>\n<maxRefinedTraits:14>\n<cdmBuffPlus:[200]>\n<thisHit:120>\n<thisCri:50>","description":"One twist of the shaft leaves a hole that will not close.\nWielded in both hands, may apply \\State[15](10%) on-hit.","iconIndex":410,"traits":[{"code":31,"dataId":2,"value":0},{"code":32,"dataId":15,"value":0.1},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,120,0,0,0,200,0],"price":500000,"animationId":11,"wtypeId":4},
-{"id":36,"name":"Bloodletter","note":"<skillId:31>\n<offhandSkillId:34>\n<speedBoost:15>\n<maxRefineCount:50>\n<maxRefinedTraits:20>\n<cdmBuffPlus:[250]>\n<thisHit:150>\n<thisCri:65>","description":"Its barbs are angled to open on the way out, not the way in.\nWielded in both hands, may apply \\State[15](20%) on-hit.","iconIndex":410,"traits":[{"code":31,"dataId":2,"value":0},{"code":32,"dataId":15,"value":0.2},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,160,0,0,0,260,0],"price":999999,"animationId":11,"wtypeId":4},
-{"id":37,"name":"\"Akai Supeeya\"","note":"<skillId:31>\n<offhandSkillId:34>\n<speedBoost:10>\n<notRefinementBase>\n<notRefinementMaterial>\n<cdmBuffPlus:[150]>\n<thisHit:70>\n<thisCri:15>","description":"⭐ It might be... from a foreign land... but it also might be a knock-off... At least it looks flashy?\nWielded in both hands, may apply \\State[15](25%) on-hit.","iconIndex":409,"traits":[{"code":31,"dataId":2,"value":0},{"code":32,"dataId":15,"value":0.25},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,25,0,0,0,40,0],"price":0,"animationId":12,"wtypeId":4},
-{"id":38,"name":"\"Crimson Stabber\"","note":"<skillId:31>\n<offhandSkillId:34>\n<speedBoost:15>\n<notRefinementBase>\n<notRefinementMaterial>\n<cdmBuffPlus:[150]>\n<thisHit:110>\n<thisCri:40>","description":"⭐⭐ The lethality of this blade is unmistakable. Blood everywhere.\nWielded in both hands, may apply \\State[15](50%) on-hit.","iconIndex":580,"traits":[{"code":31,"dataId":2,"value":0},{"code":32,"dataId":15,"value":0.5},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,110,0,0,0,175,6],"price":0,"animationId":12,"wtypeId":4},
-{"id":39,"name":"\"Rhongomyniad\"","note":"<skillId:31>\n<offhandSkillId:34>\n<speedBoost:20>\n<notRefinementBase>\n<notRefinementMaterial>\n<cdmBuffPlus:[400]>\n<thisHit:150>\n<thisCri:80>","description":"⭐⭐⭐ An ascended spear that is makes you bleed just by looking at it.\nWielded in both hands, applies \\State[15] on-hit.","iconIndex":582,"traits":[{"code":31,"dataId":2,"value":0},{"code":32,"dataId":15,"value":1},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,220,0,0,0,300,6],"price":0,"animationId":12,"wtypeId":4},
-{"id":40,"name":"\"Ichor\"","note":"<skillId:31>\n<offhandSkillId:34>\n<speedBoost:25>\n<notRefinementMaterial>\n<thisHit:300>\n<thisCri:180>","description":"They say that gods do not bleed; this went looking anyway.\nWielded in both hands.","iconIndex":582,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":10,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,300,0,0,0,480,0],"price":0,"animationId":12,"wtypeId":4},
-{"id":41,"name":"Basher","note":"<skillId:41>\n<offhandSkillId:45>\n<maxRefineCount:4>\n<maxRefinedTraits:4>\n<cdmBuffPlus:[20]>\n<thisHit:60>\n<thisCri:5>","description":"Though this is classified as a \"spear\", it is rather more a ball on a stick.\nWielded in both hands, may apply \\State[8](5%) on-hit.","iconIndex":1753,"traits":[{"code":31,"dataId":3,"value":0},{"code":32,"dataId":8,"value":0.05},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,5,0,15,15,0,0],"price":1000,"animationId":1,"wtypeId":5},
-{"id":42,"name":"Smasher","note":"<skillId:41>\n<offhandSkillId:45>\n<maxRefineCount:10>\n<maxRefinedTraits:6>\n<cdmBuffPlus:[40]>\n<thisHit:100>\n<thisCri:15>","description":"We aren't getting any closer, but this absolutely will smash some skulls.\nWielded in both hands, may apply \\State[8](5%) on-hit.","iconIndex":1357,"traits":[{"code":31,"dataId":3,"value":0},{"code":32,"dataId":8,"value":0.05},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,20,0,50,50,0,0],"price":25000,"animationId":1,"wtypeId":5},
-{"id":43,"name":"Flasher","note":"<skillId:41>\n<offhandSkillId:45>\n<maxRefineCount:16>\n<maxRefinedTraits:8>\n<cdmBuffPlus:[50]>\n<thisHit:140>\n<thisCri:20>","description":"A flashy and fabulously smashtastic weapon for bashing your foes.\nWielded in both hands, may apply \\State[8](5%) on-hit.","iconIndex":425,"traits":[{"code":31,"dataId":3,"value":0},{"code":32,"dataId":8,"value":0.05},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,25,0,85,85,0,0],"price":100000,"animationId":1,"wtypeId":5},
-{"id":44,"name":"Clasher","note":"<skillId:41>\n<offhandSkillId:45>\n<maxRefineCount:24>\n<maxRefinedTraits:10>\n<cdmBuffPlus:[80]>\n<thisHit:260>\n<thisCri:35>","description":"A deadly and dangerous \"spear\", far and beyond something to poke with, just shove it at them.\nWielded in both hands, may apply \\State[8](5%) on-hit.","iconIndex":426,"traits":[{"code":31,"dataId":3,"value":0},{"code":32,"dataId":8,"value":0.05},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,40,0,110,110,0,0],"price":500000,"animationId":1,"wtypeId":5},
-{"id":45,"name":"Thrasher","note":"<skillId:41>\n<offhandSkillId:45>\n<maxRefineCount:36>\n<maxRefinedTraits:14>\n<cdmBuffPlus:[110]>\n<thisHit:340>\n<thisCri:45>","description":"Whatever poking this could do was abandoned somewhere around the third swing.\nWielded in both hands, may apply \\State[8](5%) on-hit.","iconIndex":425,"traits":[{"code":31,"dataId":3,"value":0},{"code":32,"dataId":8,"value":0.05},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,55,0,145,145,0,0],"price":750000,"animationId":1,"wtypeId":5},
-{"id":46,"name":"Crasher","note":"<skillId:41>\n<offhandSkillId:45>\n<maxRefineCount:50>\n<maxRefinedTraits:20>\n<cdmBuffPlus:[150]>\n<thisHit:420>\n<thisCri:60>","description":"Still filed under \"spear\", and at this point that is purely a paperwork problem.\nWielded in both hands, may apply \\State[8](5%) on-hit.","iconIndex":426,"traits":[{"code":31,"dataId":3,"value":0},{"code":32,"dataId":8,"value":0.05},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,75,0,185,185,0,0],"price":999999,"animationId":1,"wtypeId":5},
-{"id":47,"name":"\"Concussivity\"","note":"<skillId:41>\n<offhandSkillId:45>\n<notRefinementBase>\n<notRefinementMaterial>\n<cdmBuffPlus:[40]>\n<thisHit:70>\n<thisCri:10>","description":"⭐ At this point, we aren't even trying to hide the lack of spear-ness.\nImbued with \"Ground\", may apply \\State[12](25%) and \\State[8](5%) on-hit, wielded in both hands.","iconIndex":424,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":7,"value":0},{"code":32,"dataId":12,"value":0.25},{"code":32,"dataId":8,"value":0.05},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,23,0,60,60,0,0],"price":0,"animationId":12,"wtypeId":5},
-{"id":48,"name":"\"Ground Pounder\"","note":"<skillId:41>\n<offhandSkillId:45>\n<notRefinementBase>\n<notRefinementMaterial>\n<cdmBuffPlus:[70]>\n<thisHit:225>\n<thisCri:25>","description":"⭐⭐ A massive hammer designed for crushing skulls- exactly as you aim to do.\nImbued with \"Ground\", may apply \\State[12](50%) on-hit and \\State[8](10%) on-hit, wielded in both hands.","iconIndex":547,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":7,"value":0},{"code":32,"dataId":12,"value":0.5},{"code":32,"dataId":8,"value":0.1},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,50,0,140,140,0,0],"price":0,"animationId":12,"wtypeId":5},
-{"id":49,"name":"\"Daedalus\"","note":"<skillId:41>\n<offhandSkillId:45>\n<notRefinementBase>\n<notRefinementMaterial>\n<cdmBuffPlus:[100]>\n<thisHit:350>\n<thisCri:40>","description":"⭐⭐⭐ An ascended smashing tool, crafted by a legendary smith of unparalleled skill.\nImbued with \"Ground\", applies \\State[12] and maybe \\State[8](15%) on-hit, wielded in both hands, destroys shielded foes.","iconIndex":1626,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":7,"value":0},{"code":31,"dataId":23,"value":0},{"code":32,"dataId":12,"value":1},{"code":32,"dataId":8,"value":0.15},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,100,0,200,200,0,6],"price":0,"animationId":12,"wtypeId":5},
-{"id":50,"name":"\"Seismos\"","note":"<skillId:41>\n<offhandSkillId:45>\n<notRefinementMaterial>\n<cdmBuffPlus:[200]>\n<thisHit:500>\n<thisCri:80>","description":"The ground does not break where it is struck; it breaks everywhere else.\nWielded in both hands.","iconIndex":1626,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":10,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,150,0,370,370,0,0],"price":0,"animationId":12,"wtypeId":5},
-{"id":51,"name":"Floppy Dart","note":"<skillId:51>\n<offhandSkillId:53>\n<speedBoost:15>\n<maxRefineCount:2>\n<maxRefinedTraits:2>\n<cdmBuffPlus:[50]>\n<thisHit:10>\n<thisCri:30>","description":"The shaft has more give in it than anyone would like, but it still lands point-first. Usually.","iconIndex":408,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,20,0,0,0,5,0],"price":1000,"animationId":11,"wtypeId":6},
-{"id":52,"name":"Whaling Harpoon","note":"<skillId:51>\n<offhandSkillId:53>\n<speedBoost:15>\n<maxRefineCount:5>\n<maxRefinedTraits:3>\n<cdmBuffPlus:[70]>\n<thisHit:40>\n<thisCri:60>","description":"An excellent harpoon that was used in ancient times to puncture whale hide.","iconIndex":1634,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,70,0,0,0,15,0],"price":25000,"animationId":11,"wtypeId":6},
-{"id":53,"name":"Kaboom Needle","note":"<skillId:51>\n<offhandSkillId:53>\n<speedBoost:20>\n<maxRefineCount:8>\n<maxRefinedTraits:4>\n<cdmBuffPlus:[80]>\n<thisHit:60>\n<thisCri:75>","description":"While sharp spears are great, exploding spears are typically even greater.","iconIndex":502,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,115,0,0,0,20,0],"price":50000,"animationId":11,"wtypeId":6},
-{"id":54,"name":"Harisakeru","note":"<skillId:51>\n<offhandSkillId:53>\n<speedBoost:20>\n<maxRefineCount:12>\n<maxRefinedTraits:5>\n<cdmBuffPlus:[100]>\n<thisHit:80>\n<thisCri:120>","description":"Exacerbating explosive spears leads to super deadly and explosive spears.","iconIndex":1629,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,200,0,0,0,40,0],"price":500000,"animationId":11,"wtypeId":6},
-{"id":55,"name":"Pilum","note":"<skillId:51>\n<offhandSkillId:53>\n<speedBoost:20>\n<maxRefineCount:18>\n<maxRefinedTraits:7>\n<cdmBuffPlus:[130]>\n<thisHit:110>\n<thisCri:150>","description":"Its shank is meant to bend on impact, so that pulling it back out is somebody else's problem.","iconIndex":502,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,270,0,0,0,55,0],"price":750000,"animationId":11,"wtypeId":6},
-{"id":56,"name":"Shrike","note":"<skillId:51>\n<offhandSkillId:53>\n<speedBoost:25>\n<maxRefineCount:25>\n<maxRefinedTraits:10>\n<cdmBuffPlus:[160]>\n<thisHit:140>\n<thisCri:185>","description":"Named for the bird that leaves what it catches hanging on a thorn, still fresh.","iconIndex":1629,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,350,0,0,0,70,0],"price":999999,"animationId":11,"wtypeId":6},
-{"id":57,"name":"\"Fish Eater\"","note":"<skillId:51>\n<offhandSkillId:53>\n<speedBoost:15>\n<notRefinementBase>\n<notRefinementMaterial>\n<cdmBuffPlus:[100]>\n<thisHit:30>\n<thisCri:50>","description":"⭐ Excellent at piercing any type of aquatic animal thanks to its razor sharp point.","iconIndex":878,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0},{"code":31,"dataId":13,"value":0}],"etypeId":1,"params":[0,0,75,0,25,0,18,0],"price":0,"animationId":12,"wtypeId":6},
-{"id":58,"name":"\"Sauroter\"","note":"<skillId:51>\n<offhandSkillId:53>\n<speedBoost:20>\n<notRefinementBase>\n<notRefinementMaterial>\n<cdmBuffPlus:[125]>\n<thisHit:75>\n<thisCri:100>","description":"⭐⭐ The addition of serration enables slaying both aquatic and reptiles effortlessly.","iconIndex":879,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0},{"code":31,"dataId":13,"value":0},{"code":31,"dataId":12,"value":0}],"etypeId":1,"params":[0,0,225,0,100,0,50,0],"price":0,"animationId":12,"wtypeId":6},
-{"id":59,"name":"\"Vel\"","note":"<skillId:51>\n<offhandSkillId:53>\n<speedBoost:25>\n<notRefinementBase>\n<notRefinementMaterial>\n<cdmBuffPlus:[150]>\n<thisHit:100>\n<thisCri:150>","description":"⭐⭐⭐ An ascended javelin said to pierce anything, including aquatics, reptiles, and deities.","iconIndex":1630,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0},{"code":31,"dataId":13,"value":0},{"code":31,"dataId":12,"value":0},{"code":31,"dataId":20,"value":0}],"etypeId":1,"params":[0,0,500,0,200,0,100,0],"price":0,"animationId":12,"wtypeId":6},
-{"id":60,"name":"\"Stigmata\"","note":"<skillId:51>\n<offhandSkillId:53>\n<speedBoost:30>\n<notRefinementMaterial>\n<cdmBuffPlus:[200]>\n<thisHit:200>\n<thisCri:250>","description":"Every hole it leaves stays open, and they all come due at once.","iconIndex":1630,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0},{"code":31,"dataId":10,"value":0}],"etypeId":1,"params":[0,0,600,0,0,0,120,0],"price":0,"animationId":12,"wtypeId":6},
-{"id":61,"name":"Zip Gun","note":"<skillId:61>\n<offhandSkillId:64>\n<maxRefineCount:2>\n<maxRefinedTraits:2>\n<thisHit:20>\n<thisCri:10>\n<thisTrg:2>","description":"A pipe, a nail, and a rubber band. It fires about as well as that sounds,\nwhich is to say it is a tier-1 weapon.","iconIndex":104,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,10,0,0,0,0,10],"price":100,"animationId":125,"wtypeId":7},
-{"id":62,"name":"Beretta","note":"<skillId:61>\n<offhandSkillId:64>\n<maxRefineCount:5>\n<maxRefinedTraits:3>\n<thisHit:30>\n<thisCri:15>\n<thisTrg:2>","description":"A standard everyday pistol.\nShoots bullets, in case you were unaware.","iconIndex":2518,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,15,0,0,0,0,15],"price":1000,"animationId":125,"wtypeId":7},
-{"id":63,"name":"Magnum","note":"<skillId:61>\n<offhandSkillId:64>\n<maxRefineCount:8>\n<maxRefinedTraits:4>\n<thisHit:40>\n<thisCri:25>\n<thisTrg:3>","description":"A magnum, the king of classic pistols.\nFires with a over-compensating BANG.","iconIndex":2515,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,25,0,0,0,0,25],"price":25000,"animationId":125,"wtypeId":7},
-{"id":64,"name":"Deagle","note":"<skillId:61>\n<offhandSkillId:64>\n<maxRefineCount:12>\n<maxRefinedTraits:5>\n<thisHit:50>\n<thisCri:40>\n<thisTrg:3>","description":"If two magnums had a baby, it'd be this.\nBecause it blows you into chunks with a single shot.","iconIndex":2516,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,60,0,0,0,0,60],"price":250000,"animationId":125,"wtypeId":7},
-{"id":65,"name":"Zeliska","note":"<skillId:61>\n<offhandSkillId:64>\n<maxRefineCount:18>\n<maxRefinedTraits:7>\n<thisHit:80>\n<thisCri:50>\n<thisTrg:4>","description":"Six kilograms of revolver, chambered for a round meant to stop an elephant.\nAiming it is optional. Surviving it is not.","iconIndex":2516,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,90,0,0,0,0,90],"price":500000,"animationId":125,"wtypeId":7},
-{"id":66,"name":"KS Model 1337","note":"<skillId:61>\n<offhandSkillId:64>\n<maxRefineCount:25>\n<maxRefinedTraits:10>\n<thisHit:110>\n<thisCri:70>\n<thisTrg:5>","description":"Thanks to advancements in technology,\nyour gun now looks as cool as it is lethal.","iconIndex":1553,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,130,0,0,0,0,130],"price":999999,"animationId":125,"wtypeId":7},
-{"id":67,"name":"\"Burning Bullet\"","note":"<skillId:61>\n<offhandSkillId:64>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:40>\n<thisCri:40>\n<thisTrg:3>","description":"⭐ A pistol that fires angry bullets to slay its foes.\nImbued with \"Heat\", has high crit.","iconIndex":78,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":4,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,20,0,0,0,0,20],"price":0,"animationId":125,"wtypeId":7},
-{"id":68,"name":"\"Hellfire Shot\"","note":"<skillId:61>\n<offhandSkillId:64>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:70>\n<thisCri:100>\n<thisTrg:4>","description":"⭐⭐ A raging pistol powered by your hatred.\nImbued with \"Heat\", has high crit.","iconIndex":1505,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":4,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,70,0,0,0,0,70],"price":0,"animationId":125,"wtypeId":7},
-{"id":69,"name":"\"Xiuhcoatl\"","note":"<skillId:61>\n<offhandSkillId:64>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:100>\n<thisCri:200>\n<thisTrg:5>","description":"⭐⭐⭐ An ascended pistol that basically breathes flame bullets on your behalf.\nImbued with \"Heat\", has high crit.","iconIndex":867,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":4,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,200,0,0,0,0,200],"price":0,"animationId":125,"wtypeId":7},
-{"id":70,"name":"\"Verdict\"","note":"<skillId:61>\n<offhandSkillId:64>\n<notRefinementMaterial>\n<thisHit:200>\n<thisCri:300>\n<thisTrg:6>","description":"Everything that came before it was argument.\nThis is only the part where it is settled.","iconIndex":867,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0},{"code":31,"dataId":10,"value":0}],"etypeId":1,"params":[0,0,260,0,0,0,0,260],"price":0,"animationId":125,"wtypeId":7},
-{"id":71,"name":"10-Volt Stun Gun","note":"<skillId:71>\n<offhandSkillId:74>\n<maxRefineCount:2>\n<maxRefinedTraits:2>\n<thisHit:50>\n<thisCri:1>\n<thisTrg:5>","description":"A stun gun with a weak battery.\nIt is effectively a training weapon at this point.","iconIndex":1523,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":13,"value":0}],"etypeId":1,"params":[0,0,0,0,15,0,0,5],"price":1000,"animationId":5,"wtypeId":8},
-{"id":72,"name":"Butthole Tingler","note":"<skillId:71>\n<offhandSkillId:74>\n<maxRefineCount:5>\n<maxRefinedTraits:3>\n<thisHit:70>\n<thisCri:1>\n<thisTrg:5>","description":"After replacing the battery, the stun gun is now a STUN GUN.","iconIndex":1523,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":13,"value":0}],"etypeId":1,"params":[0,0,0,0,30,0,0,10],"price":10000,"animationId":5,"wtypeId":8},
-{"id":73,"name":"10000-Volt Stun Gun","note":"<skillId:71>\n<offhandSkillId:74>\n<maxRefineCount:8>\n<maxRefinedTraits:4>\n<thisHit:110>\n<thisCri:2>\n<thisTrg:5>","description":"An extremely well-advertised and obviously good brand of battery powers this stun gun.","iconIndex":1523,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":13,"value":0}],"etypeId":1,"params":[0,0,0,0,90,0,0,25],"price":50000,"animationId":5,"wtypeId":8},
-{"id":74,"name":"Teravolt Stun Gun","note":"<skillId:71>\n<offhandSkillId:74>\n<maxRefineCount:12>\n<maxRefinedTraits:5>\n<thisHit:190>\n<thisCri:2>\n<thisTrg:5>","description":"Packing a massive battery, you can release untold torrents of destruction on your foes.","iconIndex":1523,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":13,"value":0}],"etypeId":1,"params":[0,0,0,0,195,0,0,80],"price":500000,"animationId":5,"wtypeId":8},
-{"id":75,"name":"Petavolt Stun Gun","note":"<skillId:71>\n<offhandSkillId:74>\n<maxRefineCount:18>\n<maxRefinedTraits:7>\n<thisHit:260>\n<thisCri:2>\n<thisTrg:5>","description":"The battery is not sold in stores, and the man who sold it to you seemed nervous about it.","iconIndex":1523,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":13,"value":0}],"etypeId":1,"params":[0,0,0,0,290,0,0,140],"price":750000,"animationId":5,"wtypeId":8},
-{"id":76,"name":"Exavolt Stun Gun","note":"<skillId:71>\n<offhandSkillId:74>\n<maxRefineCount:25>\n<maxRefinedTraits:10>\n<thisHit:340>\n<thisCri:2>\n<thisTrg:5>","description":"Whatever is in the battery compartment is not, strictly speaking, a battery anymore.","iconIndex":1523,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":13,"value":0}],"etypeId":1,"params":[0,0,0,0,400,0,0,210],"price":999999,"animationId":5,"wtypeId":8},
-{"id":77,"name":"\"Fly Zapper\"","note":"<skillId:71>\n<offhandSkillId:74>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:90>\n<thisCri:1>\n<thisTrg:10>","description":"⭐ A bugzapper that had some DIY work to make it projectile-worthy.\nDestroys insects.","iconIndex":1535,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":13,"value":0},{"code":31,"dataId":17,"value":0}],"etypeId":1,"params":[0,0,0,0,50,0,0,20],"price":0,"animationId":5,"wtypeId":8},
-{"id":78,"name":"\"Defoliant\"","note":"<skillId:71>\n<offhandSkillId:74>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:160>\n<thisCri:2>\n<thisTrg:5>","description":"⭐⭐ If you continue to overcharge a bugzapper, it'll start destroying foliage, too.\nDestroys insects and plants.","iconIndex":1535,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":13,"value":0},{"code":31,"dataId":17,"value":0},{"code":31,"dataId":15,"value":0}],"etypeId":1,"params":[0,0,0,0,200,0,0,100],"price":0,"animationId":5,"wtypeId":8},
-{"id":79,"name":"\"Teen Baan\"","note":"<skillId:71>\n<offhandSkillId:74>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:250>\n<thisCri:2>\n<thisTrg:5>","description":"⭐⭐⭐ A stun gun with an ascended battery, capable of obliterating all of humanity.\nDestroys insects, plants, and humanoids.","iconIndex":1535,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":13,"value":0},{"code":31,"dataId":17,"value":0},{"code":31,"dataId":15,"value":0},{"code":31,"dataId":18,"value":0}],"etypeId":1,"params":[0,0,0,0,500,0,0,300],"price":0,"animationId":5,"wtypeId":8},
-{"id":80,"name":"\"Vitrification\"","note":"<skillId:71>\n<offhandSkillId:74>\n<notRefinementMaterial>\n<thisHit:450>\n<thisCri:2>\n<thisTrg:5>","description":"Nothing scatters and nothing burns. There is only a smooth place where something used to be.","iconIndex":1535,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":13,"value":0},{"code":31,"dataId":10,"value":0}],"etypeId":1,"params":[0,0,0,0,800,0,0,400],"price":0,"animationId":5,"wtypeId":8},
-{"id":81,"name":"Scattershot","note":"<skillId:81>\n<offhandSkillId:83>\n<speedBoost:-10>\n<maxRefineCount:4>\n<maxRefinedTraits:4>\n<thisHit:5>\n<thisCri:4>\n<thisTrg:1>\n<thisRec:30>","description":"Your standard in shotguns. A bit heavy and rusty, but requires less effort.\nWielded in both hands.","iconIndex":436,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,20,0,0,0,0,5],"price":1000,"animationId":125,"wtypeId":9},
-{"id":82,"name":"Tribarrel","note":"<skillId:81>\n<offhandSkillId:83>\n<speedBoost:-10>\n<maxRefineCount:10>\n<maxRefinedTraits:6>\n<thisHit:20>\n<thisCri:6>\n<thisTrg:1>\n<thisRec:75>","description":"A triple-barrel shotgun for firing three times at once.\nWielded in both hands.","iconIndex":436,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,50,0,0,0,0,15],"price":10000,"animationId":125,"wtypeId":9},
-{"id":83,"name":"Decabarrel","note":"<skillId:81>\n<offhandSkillId:83>\n<speedBoost:-10>\n<maxRefineCount:16>\n<maxRefinedTraits:8>\n<thisHit:40>\n<thisCri:8>\n<thisTrg:2>\n<thisRec:110>","description":"A 10-barrel shotgun for firing ten times at once.\nWielded in both hands.","iconIndex":436,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,95,0,0,0,0,30],"price":50000,"animationId":125,"wtypeId":9},
-{"id":84,"name":"Centibarrel","note":"<skillId:81>\n<offhandSkillId:83>\n<speedBoost:-10>\n<maxRefineCount:24>\n<maxRefinedTraits:10>\n<thisHit:60>\n<thisCri:10>\n<thisTrg:2>\n<thisRec:160>","description":"A 100-barrel shotgun for firing ...not 100 times at once, but it does hit a lot!\nWielded in both hands.","iconIndex":436,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,210,0,0,0,0,70],"price":500000,"animationId":125,"wtypeId":9},
-{"id":85,"name":"Kilobarrel","note":"<skillId:81>\n<offhandSkillId:83>\n<speedBoost:-10>\n<maxRefineCount:36>\n<maxRefinedTraits:14>\n<thisHit:85>\n<thisCri:12>\n<thisTrg:3>\n<thisRec:210>","description":"A 1000-barrel shotgun. Nobody has counted them, and nobody is going to.\nWielded in both hands.","iconIndex":436,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,340,0,0,0,0,110],"price":750000,"animationId":125,"wtypeId":9},
-{"id":86,"name":"Megabarrel","note":"<skillId:81>\n<offhandSkillId:83>\n<speedBoost:-10>\n<maxRefineCount:50>\n<maxRefinedTraits:20>\n<thisHit:110>\n<thisCri:15>\n<thisTrg:3>\n<thisRec:260>","description":"A million barrels, allegedly. The paperwork burned up along with everything else.\nWielded in both hands.","iconIndex":436,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,480,0,0,0,0,160],"price":999999,"animationId":125,"wtypeId":9},
-{"id":87,"name":"\"Blaster\"","note":"<skillId:81>\n<offhandSkillId:83>\n<speedBoost:-10>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:10>\n<thisCri:10>\n<thisTrg:4>\n<thisRec:50>","description":"⭐ A unique-shaped gun for blasting holes through bitches.\nDestroys undead.","iconIndex":1457,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":11,"value":0},{"code":31,"dataId":22,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,75,0,0,0,0,25],"price":0,"animationId":125,"wtypeId":9},
-{"id":88,"name":"\"Spray of Death\"","note":"<skillId:81>\n<offhandSkillId:83>\n<speedBoost:-10>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:65>\n<thisCri:15>\n<thisTrg:5>\n<thisRec:135>","description":"⭐⭐ A ruthless shotgun for dealing with your average zombie apocalypse.\nDestroys undead.","iconIndex":1457,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":11,"value":0},{"code":31,"dataId":22,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,300,0,0,0,0,100],"price":0,"animationId":125,"wtypeId":9},
-{"id":89,"name":"\"Astra\"","note":"<skillId:81>\n<offhandSkillId:83>\n<speedBoost:-10>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:75>\n<thisCri:20>\n<thisTrg:6>\n<thisRec:200>","description":"⭐⭐⭐ A shotgun with ascended barrels for obliterating even beezlebub in one shot.\nBanishes undead.","iconIndex":1457,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":11,"value":0},{"code":31,"dataId":22,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,500,0,0,0,0,200],"price":0,"animationId":125,"wtypeId":9},
-{"id":90,"name":"\"Legion\"","note":"<skillId:81>\n<offhandSkillId:83>\n<speedBoost:-10>\n<notRefinementMaterial>\n<thisHit:150>\n<thisCri:25>\n<thisTrg:8>\n<thisRec:350>","description":"Ask it what it is called, and every barrel answers.\nWielded in both hands.","iconIndex":1457,"traits":[{"code":31,"dataId":2,"value":0},{"code":31,"dataId":22,"value":0},{"code":31,"dataId":10,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,960,0,0,0,0,320],"price":0,"animationId":125,"wtypeId":9},
-{"id":91,"name":"Kindling Hatchet","note":"<skillId:91>\n<offhandSkillId:94>\n<speedBoost:-10>\n<maxRefineCount:2>\n<maxRefinedTraits:2>\n<thisHit:15>\n<thisCri:4>","description":"An axe sized for splitting kindling and absolutely nothing else.\nIt has never met anything that fought back.","iconIndex":99,"traits":[{"code":31,"dataId":1,"value":0}],"etypeId":1,"params":[50,0,25,0,0,0,0,0],"price":100,"animationId":7,"wtypeId":10},
-{"id":92,"name":"Wolftrap Maul","note":"<skillId:91>\n<offhandSkillId:94>\n<speedBoost:-10>\n<maxRefineCount:5>\n<maxRefinedTraits:3>\n<thisHit:25>\n<thisCri:6>","description":"A beginner's maul designed for easing woodchopping, but laced with wolftrap sap.\nMay apply \\State[16](20%).","iconIndex":432,"traits":[{"code":31,"dataId":1,"value":0},{"code":32,"dataId":16,"value":0.2}],"etypeId":1,"params":[80,0,45,0,0,0,0,0],"price":1000,"animationId":7,"wtypeId":10},
-{"id":93,"name":"Beartrap Hewer","note":"<skillId:91>\n<offhandSkillId:94>\n<speedBoost:-15>\n<maxRefineCount:8>\n<maxRefinedTraits:4>\n<thisHit:35>\n<thisCri:10>","description":"A hewing axe glazed with resin bled from a beartrap.\nMay apply \\State[16](40%).","iconIndex":1728,"traits":[{"code":31,"dataId":1,"value":0},{"code":32,"dataId":16,"value":0.4}],"etypeId":1,"params":[115,0,70,0,0,0,0,0],"price":5000,"animationId":7,"wtypeId":10},
-{"id":94,"name":"Orctrap Cleaver","note":"<skillId:91>\n<offhandSkillId:94>\n<speedBoost:-15>\n<maxRefineCount:12>\n<maxRefinedTraits:5>\n<thisHit:50>\n<thisCri:15>","description":"A heavy cleaver capable of doing some serious damage, laced with orctrap venom.\nMay apply \\State[16](60%).","iconIndex":1728,"traits":[{"code":31,"dataId":1,"value":0},{"code":32,"dataId":16,"value":0.6}],"etypeId":1,"params":[160,0,100,0,0,0,0,0],"price":25000,"animationId":7,"wtypeId":10},
-{"id":95,"name":"Wyrmtrap Maul","note":"<skillId:91>\n<offhandSkillId:94>\n<speedBoost:-15>\n<maxRefineCount:18>\n<maxRefinedTraits:7>\n<thisHit:75>\n<thisCri:25>","description":"A wicked axe with a tremendous heft to it, laced with the bile of a wyrmtrap.\nMay apply \\State[16](80%).","iconIndex":433,"traits":[{"code":31,"dataId":1,"value":0},{"code":32,"dataId":16,"value":0.8}],"etypeId":1,"params":[280,0,160,0,0,0,0,0],"price":100000,"animationId":7,"wtypeId":10},
-{"id":96,"name":"Deathtrap Broadaxe","note":"<skillId:91>\n<offhandSkillId:94>\n<speedBoost:-20>\n<maxRefineCount:25>\n<maxRefinedTraits:10>\n<thisHit:120>\n<thisCri:35>","description":"An axe glazed entirely with the most lethal venom in the galaxy: the Deathtrap.\nApplies \\State[16].","iconIndex":434,"traits":[{"code":31,"dataId":1,"value":0},{"code":32,"dataId":16,"value":1}],"etypeId":1,"params":[400,0,215,0,0,0,0,0],"price":500000,"animationId":7,"wtypeId":10},
-{"id":97,"name":"\"Glowing Hacker\"","note":"<skillId:91>\n<offhandSkillId:94>\n<speedBoost:-10>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:60>\n<thisCri:10>","description":"⭐ A small glowing axe, which feels static to the touch.\nDestroys constructs.","iconIndex":563,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":19,"value":0}],"etypeId":1,"params":[100,0,60,0,0,0,0,0],"price":0,"animationId":7,"wtypeId":10},
-{"id":98,"name":"\"Sky Splitter\"","note":"<skillId:91>\n<offhandSkillId:94>\n<speedBoost:-10>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:70>\n<thisCri:25>","description":"⭐⭐ A dangerously charged and long axe that cleaves the skies.\nDestroys constructs.","iconIndex":515,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":19,"value":0}],"etypeId":1,"params":[200,0,150,0,0,0,0,0],"price":0,"animationId":7,"wtypeId":10},
-{"id":99,"name":"\"Mjolnir\"","note":"<skillId:91>\n<offhandSkillId:94>\n<speedBoost:-15>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:150>\n<thisCri:40>","description":"⭐⭐⭐ An ascended axe- I mean chainsaw- capable of rending all asunder.\nDestroys constructs.","iconIndex":1491,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":19,"value":0}],"etypeId":1,"params":[600,0,250,0,0,0,0,0],"price":0,"animationId":7,"wtypeId":10},
-{"id":100,"name":"\"Reckoning\"","note":"<skillId:91>\n<offhandSkillId:94>\n<speedBoost:-20>\n<notRefinementMaterial>\n<thisHit:200>\n<thisCri:60>","description":"Every blow you walked away from was being counted.\nNothing walks away from this one.","iconIndex":1491,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":10,"value":0}],"etypeId":1,"params":[800,0,430,0,0,0,0,0],"price":0,"animationId":7,"wtypeId":10},
-{"id":101,"name":"Leaden Poleaxe","note":"<skillId:101>\n<maxRefineCount:4>\n<maxRefinedTraits:4>\n<thisHit:50>\n<thisCri:2>","description":"So dense it fights you on the backswing. Every hit lands late and lands anyway.\nWielded in both hands.","iconIndex":1731,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[250,0,35,0,0,0,0,0],"price":1000,"animationId":7,"wtypeId":11},
-{"id":102,"name":"Bulky Sagaris","note":"<skillId:101>\n<maxRefineCount:10>\n<maxRefinedTraits:6>\n<thisHit:55>\n<thisCri:4>","description":"A Scythian pattern rendered in far too much iron. Shorter recovery, marginally.\nWielded in both hands.","iconIndex":411,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[800,0,100,0,0,0,0,0],"price":5000,"animationId":7,"wtypeId":11},
-{"id":103,"name":"Balanced Battleaxe","note":"<skillId:101>\n<maxRefineCount:16>\n<maxRefinedTraits:8>\n<thisHit:110>\n<thisCri:6>","description":"The point where the axe stops arguing. Head and haft finally agree on where to go.\nWielded in both hands.","iconIndex":611,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[1400,0,165,0,0,0,0,0],"price":25000,"animationId":7,"wtypeId":11},
-{"id":104,"name":"Nimble Labrys","note":"<skillId:101>\n<maxRefineCount:24>\n<maxRefinedTraits:10>\n<thisHit:160>\n<thisCri:8>","description":"Twin heads, and somehow lighter than the one before it. The arc closes noticeably faster.\nWielded in both hands.","iconIndex":1730,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[2000,0,240,0,0,0,0,0],"price":125000,"animationId":7,"wtypeId":11},
-{"id":105,"name":"Featherweight Bardiche","note":"<skillId:101>\n<maxRefineCount:36>\n<maxRefinedTraits:14>\n<thisHit:220>\n<thisCri:10>","description":"A polearm you can hold at arm's length one-handed, if only to prove it.\nWielded in both hands.","iconIndex":1730,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[2700,0,325,0,0,0,0,0],"price":500000,"animationId":7,"wtypeId":11},
-{"id":106,"name":"Gossamer Halberd","note":"<skillId:101>\n<maxRefineCount:50>\n<maxRefinedTraits:20>\n<thisHit:290>\n<thisCri:12>","description":"You can see the far wall through the blade. It comes back around before you finish swinging it.\nWielded in both hands.","iconIndex":1730,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[3500,0,420,0,0,0,0,0],"price":999999,"animationId":7,"wtypeId":11},
-{"id":107,"name":"\"Crescent Blossom\"","note":"<skillId:101>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:75>\n<thisCri:5>","description":"⭐ A crescent of an axe, opening an arc barely wider than your reach.\nDestroys humanoids, wielded in both hands.","iconIndex":1733,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":18,"value":1},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[1000,0,150,0,0,0,0,0],"price":0,"animationId":7,"wtypeId":11},
-{"id":108,"name":"\"Half-Moon Bloom\"","note":"<skillId:101>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:125>\n<thisCri:10>","description":"⭐⭐ The arc widens past half a circle, and nothing inside it gets a say.\nWielded in both hands.","iconIndex":1732,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[2500,0,300,0,0,0,0,0],"price":0,"animationId":7,"wtypeId":11},
-{"id":109,"name":"\"Ecliptic Efflorescence\"","note":"<skillId:101>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:225>\n<thisCri:15>","description":"⭐⭐⭐ The swing closes on itself. Everything within the arc is simply gone.\nWielded in both hands.","iconIndex":122,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[4500,0,500,0,0,0,0,0],"price":0,"animationId":7,"wtypeId":11},
-{"id":110,"name":"\"The Styrofoam Axe\"","note":"<skillId:101>\n<notRefinementMaterial>\n<thisHit:400>\n<thisCri:30>","description":"Weighs nothing. Has never chipped, never bent, and has never once failed\nto go all the way through. Wielded in both hands.","iconIndex":122,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":10,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[7000,0,840,0,0,0,0,0],"price":0,"animationId":7,"wtypeId":11},
-{"id":111,"name":"Khopesh","note":"<skillId:111>\n<offhandSkillId:115>\n<speedBoost:-5>\n<ignoreParry:10>\n<maxRefineCount:4>\n<maxRefinedTraits:4>\n<thisHit:30>\n<thisCri:15>","description":"A bronze sickle-sword whose hook exists to drag a shield out of the way.\nWielded in both hands.","iconIndex":518,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[50,0,30,0,0,0,0,0],"price":500,"animationId":7,"wtypeId":12},
-{"id":112,"name":"Shotel","note":"<skillId:111>\n<offhandSkillId:115>\n<speedBoost:-5>\n<ignoreParry:20>\n<maxRefineCount:10>\n<maxRefinedTraits:6>\n<thisHit:80>\n<thisCri:25>","description":"Curved so far past sense that it reaches around a shield to the man behind it.\nWielded in both hands.","iconIndex":518,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[100,0,65,0,0,0,0,0],"price":2500,"animationId":7,"wtypeId":12},
-{"id":113,"name":"Falx","note":"<skillId:111>\n<offhandSkillId:115>\n<speedBoost:-10>\n<ignoreParry:30>\n<maxRefineCount:16>\n<maxRefinedTraits:8>\n<thisHit:110>\n<thisCri:35>","description":"It came over the shield rim so hard that an empire redesigned its helmets.\nWielded in both hands.","iconIndex":518,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[300,0,100,0,0,0,0,0],"price":10000,"animationId":7,"wtypeId":12},
-{"id":114,"name":"Rhomphaia","note":"<skillId:111>\n<offhandSkillId:115>\n<speedBoost:-10>\n<ignoreParry:40>\n<maxRefineCount:24>\n<maxRefinedTraits:10>\n<thisHit:190>\n<thisCri:50>","description":"The falx given a longer shaft, so the reach arrives well before the answer does.\nWielded in both hands.","iconIndex":518,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[550,0,160,0,0,0,0,0],"price":50000,"animationId":7,"wtypeId":12},
-{"id":115,"name":"Tepoztopilli","note":"<skillId:111>\n<offhandSkillId:115>\n<speedBoost:-10>\n<ignoreParry:50>\n<maxRefineCount:36>\n<maxRefinedTraits:14>\n<thisHit:250>\n<thisCri:65>","description":"Rows of volcanic glass set along a shaft, every edge only a few atoms wide.\nWielded in both hands.","iconIndex":518,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[850,0,230,0,0,0,0,0],"price":200000,"animationId":7,"wtypeId":12},
-{"id":116,"name":"Urumi","note":"<skillId:111>\n<offhandSkillId:115>\n<speedBoost:-15>\n<ignoreParry:60>\n<maxRefineCount:50>\n<maxRefinedTraits:20>\n<thisHit:320>\n<thisCri:80>","description":"Several flexible razors that do not go through a guard so much as around it.\nWielded in both hands.","iconIndex":518,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[1200,0,310,0,0,0,0,0],"price":750000,"animationId":7,"wtypeId":12},
-{"id":117,"name":"\"Plate Peeler\"","note":"<skillId:111>\n<offhandSkillId:115>\n<speedBoost:-5>\n<ignoreParry:25>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:50>\n<thisCri:20>","description":"⭐ It gets under the edge of whatever you are wearing, and then it lifts.\nWielded in both hands.","iconIndex":614,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[200,0,75,0,0,0,0,0],"price":0,"animationId":7,"wtypeId":12},
-{"id":118,"name":"\"Bared Truth\"","note":"<skillId:111>\n<offhandSkillId:115>\n<speedBoost:-5>\n<ignoreParry:50>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:150>\n<thisCri:40>","description":"⭐⭐ By the third swing there is nothing at all left between you and it.\nWielded in both hands.","iconIndex":614,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[700,0,200,0,0,0,0,0],"price":0,"animationId":7,"wtypeId":12},
-{"id":119,"name":"\"Fragarach\"","note":"<skillId:111>\n<offhandSkillId:115>\n<ignoreParry:75>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:250>\n<thisCri:60>","description":"⭐⭐⭐ The Answerer. It cuts any shield, any wall, and any story you told about either.\nWielded in both hands.","iconIndex":614,"traits":[{"code":31,"dataId":1,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[1500,0,500,0,0,0,0,0],"price":0,"animationId":7,"wtypeId":12},
-{"id":120,"name":"\"Ablation\"","note":"<skillId:111>\n<offhandSkillId:115>\n<unparryable>\n<notRefinementMaterial>\n<thisHit:450>\n<thisCri:120>","description":"Nothing here is defeated. It is removed, one layer at a time, until there is no next layer.\nWielded in both hands.","iconIndex":614,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":10,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[2400,0,620,0,0,0,0,0],"price":0,"animationId":7,"wtypeId":12},
-{"id":121,"name":"Plain Crook","note":"<skillId:121>\n<offhandSkillId:124>\n<maxRefineCount:4>\n<maxRefinedTraits:4>\n<thisHit:10>\n<thisMrg:3>","description":"A stick. There is nothing on it. Someone has assured you it is slightly magical.\nWielded in both hands.","iconIndex":388,"traits":[{"code":31,"dataId":3,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,0,0,20,10,0,0],"price":100,"animationId":2,"wtypeId":13},
-{"id":122,"name":"Oak Staff","note":"<skillId:121>\n<offhandSkillId:124>\n<maxRefineCount:10>\n<maxRefinedTraits:6>\n<thisHit:25>\n<thisMrg:6>","description":"A well-made oaken staff, a proper accompaniment to any aspiring mage.\nWielded in both hands.","iconIndex":101,"traits":[{"code":31,"dataId":3,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,0,0,55,20,0,0],"price":1000,"animationId":2,"wtypeId":13},
-{"id":123,"name":"Mage Staff","note":"<skillId:121>\n<offhandSkillId:124>\n<maxRefineCount:16>\n<maxRefinedTraits:8>\n<thisHit:50>\n<thisMrg:8>","description":"An oaken staff adorned with dreamcatcher-like mesh.\nWielded in both hands.","iconIndex":1749,"traits":[{"code":31,"dataId":3,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,0,0,75,25,0,0],"price":5000,"animationId":2,"wtypeId":13},
-{"id":124,"name":"Bangled Staff","note":"<skillId:121>\n<offhandSkillId:124>\n<maxRefineCount:24>\n<maxRefinedTraits:10>\n<thisHit:60>\n<thisMrg:15>","description":"Hung with rings, charms and small bells. It announces you from some distance.\nWielded in both hands.","iconIndex":1741,"traits":[{"code":31,"dataId":3,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,0,0,120,40,0,0],"price":25000,"animationId":2,"wtypeId":13},
-{"id":125,"name":"Bedazzled Staff","note":"<skillId:121>\n<offhandSkillId:124>\n<maxRefineCount:36>\n<maxRefinedTraits:14>\n<thisHit:80>\n<thisMrg:18>","description":"An ancient relic of the shaman's of past. The kawaii ones, obviously.\nWielded in both hands.","iconIndex":1750,"traits":[{"code":31,"dataId":3,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,0,0,175,60,0,0],"price":100000,"animationId":2,"wtypeId":13},
-{"id":126,"name":"Overwrought Staff","note":"<skillId:121>\n<offhandSkillId:124>\n<maxRefineCount:50>\n<maxRefinedTraits:20>\n<thisHit:100>\n<thisMrg:24>","description":"Somewhere underneath all of that there is a stick, and it is doing its best.\nWielded in both hands.","iconIndex":1750,"traits":[{"code":31,"dataId":3,"value":0},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,0,0,240,85,0,0],"price":500000,"animationId":2,"wtypeId":13},
-{"id":127,"name":"\"Still Water\"","note":"<skillId:121>\n<offhandSkillId:124>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:50>\n<thisMrg:10>","description":"⭐ Placid, level, and considerably deeper than it looks.\nImbued with \"Liquid\", may apply \\State[10](25%), wielded in both hands.","iconIndex":1639,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":5,"value":0},{"code":32,"dataId":10,"value":0.25},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,0,0,70,23,0,0],"price":0,"animationId":3,"wtypeId":13},
-{"id":128,"name":"\"Quiet Drowning\"","note":"<skillId:121>\n<offhandSkillId:124>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:70>\n<thisMrg:20>","description":"⭐⭐ There is no thrashing. That part is already finished.\nImbued with \"Liquid\", may apply \\State[10](50%), wielded in both hands.","iconIndex":1746,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":5,"value":0},{"code":32,"dataId":10,"value":0.5},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,0,0,150,50,0,0],"price":0,"animationId":3,"wtypeId":13},
-{"id":129,"name":"\"Ruyi\"","note":"<skillId:121>\n<offhandSkillId:124>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:120>\n<thisMrg:30>","description":"⭐⭐⭐ The pillar that measured the depth of the seas, and then settled them.\nImbued with \"Liquid\", applies \\State[10], wielded in both hands.","iconIndex":532,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":5,"value":0},{"code":32,"dataId":10,"value":1},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,0,0,250,100,0,0],"price":0,"animationId":3,"wtypeId":13},
-{"id":130,"name":"\"Opalescence\"","note":"<skillId:121>\n<offhandSkillId:124>\n<notRefinementMaterial>\n<thisHit:200>\n<thisMrg:50>","description":"Every colour there is, held in water that must never be allowed to leave.\nApplies \\State[10]. Wielded in both hands.","iconIndex":532,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":5,"value":0},{"code":31,"dataId":10,"value":0},{"code":32,"dataId":10,"value":1},{"code":54,"dataId":2,"value":1}],"etypeId":1,"params":[0,0,0,0,500,180,0,0],"price":0,"animationId":3,"wtypeId":13},
-{"id":131,"name":"Taper Wand","note":"<skillId:131>\n<offhandSkillId:134>\n<speedBoost:15>\n<maxRefineCount:2>\n<maxRefinedTraits:2>\n<thisHit:40>\n<thisMrg:1>","description":"Narrows to a point, and concentrates almost nothing on the way through.\nDeconstructs slimes.","iconIndex":1751,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":14,"value":0}],"etypeId":1,"params":[0,0,0,0,50,0,0,0],"price":1000,"animationId":1,"wtypeId":14},
-{"id":132,"name":"Condenser Rod","note":"<skillId:131>\n<offhandSkillId:134>\n<speedBoost:15>\n<maxRefineCount:5>\n<maxRefinedTraits:3>\n<thisHit:55>\n<thisMrg:2>","description":"Gathers what you put into it, and gives most of it back at once.\nDeconstructs slimes.","iconIndex":1367,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":14,"value":0}],"etypeId":1,"params":[0,0,0,0,80,0,0,0],"price":5000,"animationId":1,"wtypeId":14},
-{"id":133,"name":"Convergence Rod","note":"<skillId:131>\n<offhandSkillId:134>\n<speedBoost:15>\n<maxRefineCount:8>\n<maxRefinedTraits:4>\n<thisHit:100>\n<thisMrg:3>","description":"Every line you draw arrives at the same place, whether it meant to or not.\nDeconstructs slimes.","iconIndex":441,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":14,"value":0}],"etypeId":1,"params":[0,0,0,0,205,0,0,0],"price":25000,"animationId":1,"wtypeId":14},
-{"id":134,"name":"Crescendo Rod","note":"<skillId:131>\n<offhandSkillId:134>\n<speedBoost:15>\n<maxRefineCount:12>\n<maxRefinedTraits:5>\n<thisHit:140>\n<thisMrg:5>","description":"The build is audible now. Bystanders have begun stepping backwards.\nDeconstructs slimes.","iconIndex":442,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":14,"value":0}],"etypeId":1,"params":[0,0,0,0,280,0,0,0],"price":100000,"animationId":1,"wtypeId":14},
-{"id":135,"name":"Culmination Rod","note":"<skillId:131>\n<offhandSkillId:134>\n<speedBoost:15>\n<maxRefineCount:18>\n<maxRefinedTraits:7>\n<thisHit:190>\n<thisMrg:8>","description":"Everything that was ever going to gather has finished gathering.\nDeconstructs slimes.","iconIndex":442,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":14,"value":0}],"etypeId":1,"params":[0,0,0,0,390,0,0,0],"price":400000,"animationId":1,"wtypeId":14},
-{"id":136,"name":"Critical Mass","note":"<skillId:131>\n<offhandSkillId:134>\n<speedBoost:15>\n<maxRefineCount:25>\n<maxRefinedTraits:10>\n<thisHit:250>\n<thisMrg:12>","description":"Past this point it proceeds with or without your further involvement.\nDeconstructs slimes.","iconIndex":442,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":14,"value":0}],"etypeId":1,"params":[0,0,0,0,520,0,0,0],"price":999999,"animationId":1,"wtypeId":14},
-{"id":137,"name":"\"First Light\"","note":"<skillId:131>\n<offhandSkillId:134>\n<speedBoost:15>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:80>\n<thisMrg:5>","description":"⭐ The moment before anyone has decided what sort of day this will be.\nImbued with \"Energy\", may apply \\State[13](25%), deconstructs slimes.","iconIndex":864,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":14,"value":0},{"code":31,"dataId":8,"value":0},{"code":32,"dataId":13,"value":0.25}],"etypeId":1,"params":[0,0,0,0,115,0,0,0],"price":0,"animationId":4,"wtypeId":14},
-{"id":138,"name":"\"Zenith\"","note":"<skillId:131>\n<offhandSkillId:134>\n<speedBoost:15>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:120>\n<thisMrg:8>","description":"⭐⭐ Directly overhead, casting no shadow at all, and impossible to look at.\nImbued with \"Energy\", may apply \\State[13](50%), deconstructs slimes.","iconIndex":727,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":14,"value":0},{"code":31,"dataId":8,"value":0},{"code":32,"dataId":13,"value":0.5}],"etypeId":1,"params":[0,0,0,0,300,0,0,0],"price":0,"animationId":4,"wtypeId":14},
-{"id":139,"name":"\"Vajra\"","note":"<skillId:131>\n<offhandSkillId:134>\n<speedBoost:15>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:200>\n<thisMrg:10>","description":"⭐⭐⭐ Thunderbolt and diamond at once- irresistible, and perfectly clear.\nImbued with \"Energy\", applies \\State[13], deconstructs slimes.","iconIndex":596,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":14,"value":0},{"code":31,"dataId":8,"value":0},{"code":32,"dataId":13,"value":1}],"etypeId":1,"params":[0,0,0,0,700,0,0,0],"price":0,"animationId":4,"wtypeId":14},
-{"id":140,"name":"\"Apotheosis\"","note":"<skillId:131>\n<offhandSkillId:134>\n<speedBoost:15>\n<notRefinementMaterial>\n<thisHit:400>\n<thisMrg:25>","description":"Everything you gathered, arriving all at once, as light.\nIt remains, technically, a punch. Applies \\State[13], deconstructs slimes.","iconIndex":596,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":14,"value":0},{"code":31,"dataId":8,"value":0},{"code":31,"dataId":10,"value":0},{"code":32,"dataId":13,"value":1}],"etypeId":1,"params":[0,0,0,0,990,0,0,0],"price":0,"animationId":4,"wtypeId":14},
-{"id":141,"name":"Pamphlet","note":"<skillId:141>\n<offhandSkillId:143>\n<maxRefineCount:2>\n<maxRefinedTraits:2>\n<thisHit:5>\n<thisMrg:2>","description":"Someone pressed this into your hand on a street corner.\nYou have not been able to put it down since.","iconIndex":1539,"traits":[{"code":31,"dataId":10,"value":0}],"etypeId":1,"params":[0,250,0,0,35,19,0,0],"price":1000,"animationId":1,"wtypeId":15},
-{"id":142,"name":"Errata","note":"<skillId:141>\n<offhandSkillId:143>\n<maxRefineCount:5>\n<maxRefinedTraits:3>\n<thisHit:15>\n<thisMrg:5>","description":"A list of every mistake in a book you were not reading.\nIt is longer than the book.","iconIndex":2062,"traits":[{"code":31,"dataId":10,"value":0}],"etypeId":1,"params":[0,400,0,0,90,55,0,0],"price":5000,"animationId":1,"wtypeId":15},
-{"id":143,"name":"Treatise","note":"<skillId:141>\n<offhandSkillId:143>\n<maxRefineCount:8>\n<maxRefinedTraits:4>\n<thisHit:60>\n<thisMrg:7>","description":"Four hundred pages arguing a point that nobody had disputed.\nThe footnotes have footnotes.","iconIndex":1548,"traits":[{"code":31,"dataId":10,"value":0}],"etypeId":1,"params":[0,950,0,0,220,150,0,0],"price":25000,"animationId":1,"wtypeId":15},
-{"id":144,"name":"Compendium","note":"<skillId:141>\n<offhandSkillId:143>\n<maxRefineCount:12>\n<maxRefinedTraits:5>\n<thisHit:70>\n<thisMrg:10>","description":"Everything known on the subject, gathered by somebody who could not stop.\nThere is no index.","iconIndex":2063,"traits":[{"code":31,"dataId":10,"value":0}],"etypeId":1,"params":[0,1200,0,0,265,210,0,0],"price":100000,"animationId":1,"wtypeId":15},
-{"id":145,"name":"Surreal Opus","note":"<skillId:141>\n<offhandSkillId:143>\n<maxRefineCount:18>\n<maxRefinedTraits:7>\n<thisHit:85>\n<thisMrg:14>","description":"The final works of one of the grandest archmages to ever live, \\_ever\\_.\nNobody has ever finished it.","iconIndex":2063,"traits":[{"code":31,"dataId":10,"value":0}],"etypeId":1,"params":[0,1600,0,0,355,285,0,0],"price":400000,"animationId":1,"wtypeId":15},
-{"id":146,"name":"Unabridged","note":"<skillId:141>\n<offhandSkillId:143>\n<maxRefineCount:25>\n<maxRefinedTraits:10>\n<thisHit:100>\n<thisMrg:18>","description":"Every word, every volume, no cuts, and the appendices are in another language.\nYou will be here a while. So will they.","iconIndex":2063,"traits":[{"code":31,"dataId":10,"value":0}],"etypeId":1,"params":[0,2100,0,0,465,375,0,0],"price":999999,"animationId":1,"wtypeId":15},
-{"id":147,"name":"\"Chained Volume\"","note":"<skillId:141>\n<offhandSkillId:143>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:65>\n<thisMrg:8>","description":"⭐ Somebody decided this one needed restraining, and they were correct.\nImbued with \"Void\", may apply \\State[14](25%).","iconIndex":2059,"traits":[{"code":31,"dataId":10,"value":0},{"code":31,"dataId":9,"value":0},{"code":32,"dataId":14,"value":0.25}],"etypeId":1,"params":[0,500,0,0,150,75,0,0],"price":0,"animationId":101,"wtypeId":15},
-{"id":148,"name":"\"Apocrypha\"","note":"<skillId:141>\n<offhandSkillId:143>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:65>\n<thisMrg:15>","description":"⭐⭐ Kept out of the canon by people who had read it first and then voted.\nImbued with \"Void\", may apply \\State[14](50%).","iconIndex":2060,"traits":[{"code":31,"dataId":10,"value":0},{"code":31,"dataId":9,"value":0},{"code":32,"dataId":14,"value":0.5}],"etypeId":1,"params":[0,1500,0,0,300,225,0,0],"price":0,"animationId":101,"wtypeId":15},
-{"id":149,"name":"\"Rauðskinna\"","note":"<skillId:141>\n<offhandSkillId:143>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:100>\n<thisMrg:20>","description":"⭐⭐⭐ Gold lettering on red vellum, buried in a grave to make quite certain of it.\nImbued with \"Void\", applies \\State[14], defeats deities.","iconIndex":2063,"traits":[{"code":31,"dataId":10,"value":0},{"code":31,"dataId":9,"value":0},{"code":31,"dataId":20,"value":0},{"code":32,"dataId":14,"value":1}],"etypeId":1,"params":[0,2500,0,0,750,450,0,0],"price":0,"animationId":101,"wtypeId":15},
-{"id":150,"name":"\"Anathema\"","note":"<skillId:141>\n<offhandSkillId:143>\n<notRefinementMaterial>\n<thisHit:200>\n<thisMrg:40>","description":"It is not so much a book as a sentence, and it has already been handed down.\nApplies \\State[14], defeats deities.","iconIndex":2063,"traits":[{"code":31,"dataId":10,"value":0},{"code":31,"dataId":9,"value":0},{"code":31,"dataId":20,"value":0},{"code":32,"dataId":14,"value":1}],"etypeId":1,"params":[0,4200,0,0,940,750,0,0],"price":0,"animationId":101,"wtypeId":15},
-{"id":151,"name":"Worn Glove","note":"<skillId:151>\n<offhandSkillId:154>\n<speedBoost:10>\n<maxRefineCount:2>\n<maxRefinedTraits:2>\n<thisHit:15>","description":"It has seen many an action. What that action was remains a mystery, so just wear it.\nImbued with \"Air\" and \"Ground\".","iconIndex":392,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":6,"value":0},{"code":31,"dataId":7,"value":0}],"etypeId":1,"params":[0,0,20,0,0,0,0,0],"price":100,"animationId":1,"wtypeId":16},
-{"id":152,"name":"Leather Fists","note":"<skillId:151>\n<offhandSkillId:154>\n<speedBoost:10>\n<maxRefineCount:5>\n<maxRefinedTraits:3>\n<thisHit:25>","description":"You only punch with one hand, so just put them both on the same hand for extra power!\nImbued with \"Air\" and \"Ground\", may apply \\State[11] and \\State[12](10%).","iconIndex":142,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":6,"value":0},{"code":31,"dataId":7,"value":0},{"code":32,"dataId":11,"value":0.1},{"code":32,"dataId":12,"value":0.1}],"etypeId":1,"params":[0,0,45,0,0,0,0,0],"price":1000,"animationId":1,"wtypeId":16},
-{"id":153,"name":"Studded Hands","note":"<skillId:151>\n<offhandSkillId:154>\n<speedBoost:10>\n<maxRefineCount:8>\n<maxRefinedTraits:4>\n<thisHit:55>","description":"Mighty hands studded with rocks and shit.\nImbued with \"Air\" and \"Ground\", may apply \\State[11] and \\State[12](20%).","iconIndex":456,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":6,"value":0},{"code":31,"dataId":7,"value":0},{"code":32,"dataId":11,"value":0.2},{"code":32,"dataId":12,"value":0.2}],"etypeId":1,"params":[0,0,80,0,0,0,0,0],"price":5000,"animationId":1,"wtypeId":16},
-{"id":154,"name":"Granite Gloves","note":"<skillId:151>\n<offhandSkillId:154>\n<speedBoost:10>\n<maxRefineCount:12>\n<maxRefinedTraits:5>\n<thisHit:90>","description":"Fists made of pure granite, meaning they are unbearably heavy.\nImbued with \"Air\" and \"Ground\", may apply \\State[11] and \\State[12](30%).","iconIndex":2588,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":6,"value":0},{"code":31,"dataId":7,"value":0},{"code":32,"dataId":11,"value":0.3},{"code":32,"dataId":12,"value":0.3}],"etypeId":1,"params":[0,0,125,0,0,0,0,0],"price":25000,"animationId":1,"wtypeId":16},
-{"id":155,"name":"Terra Fists","note":"<skillId:151>\n<offhandSkillId:154>\n<speedBoost:10>\n<maxRefineCount:18>\n<maxRefinedTraits:7>\n<thisHit:125>","description":"Fists that radiate ground energy, possibly related to \\N[3].\nImbued with \"Air\" and \"Ground\", may apply \\State[11] and \\State[12](40%).","iconIndex":553,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":6,"value":0},{"code":31,"dataId":7,"value":0},{"code":32,"dataId":11,"value":0.4},{"code":32,"dataId":12,"value":0.4}],"etypeId":1,"params":[0,0,185,0,0,0,0,0],"price":100000,"animationId":1,"wtypeId":16},
-{"id":156,"name":"Meteor Knuckles","note":"<skillId:151>\n<offhandSkillId:154>\n<speedBoost:10>\n<maxRefineCount:25>\n<maxRefinedTraits:10>\n<thisHit:170>","description":"Skystone that spent a very long time falling and has not entirely finished arriving.\nImbued with \"Air\" and \"Ground\", may apply \\State[11] and \\State[12](50%).","iconIndex":554,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":6,"value":0},{"code":31,"dataId":7,"value":0},{"code":32,"dataId":11,"value":0.5},{"code":32,"dataId":12,"value":0.5}],"etypeId":1,"params":[0,0,260,0,0,0,0,0],"price":500000,"animationId":1,"wtypeId":16},
-{"id":157,"name":"\"Empty Hand\"","note":"<skillId:151>\n<offhandSkillId:154>\n<speedBoost:10>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:80>","description":"⭐ Nothing in these hands at all, which turns out to be the entire argument.\nDisarms the weaponized, may apply \\State[7] and \\State[6](33%).","iconIndex":2578,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":21,"value":0},{"code":32,"dataId":7,"value":0.33},{"code":32,"dataId":6,"value":0.33}],"etypeId":1,"params":[0,0,60,0,0,0,0,0],"price":0,"animationId":1,"wtypeId":16},
-{"id":158,"name":"\"Nothing Left\"","note":"<skillId:151>\n<offhandSkillId:154>\n<speedBoost:10>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:100>","description":"⭐⭐ Whatever they brought with them, they are not bringing it home.\nDisarms the weaponized, may apply \\State[7] and \\State[6](66%).","iconIndex":459,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":21,"value":0},{"code":32,"dataId":7,"value":0.66},{"code":32,"dataId":6,"value":0.66}],"etypeId":1,"params":[0,0,180,0,0,0,0,0],"price":0,"animationId":1,"wtypeId":16},
-{"id":159,"name":"\"Hecatoncheire\"","note":"<skillId:151>\n<offhandSkillId:154>\n<speedBoost:10>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:150>","description":"⭐⭐⭐ A hundred hands, and not one of them holding a thing.\nDisarms the weaponized, applies \\State[7] and \\State[6].","iconIndex":2585,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":21,"value":0},{"code":32,"dataId":7,"value":1},{"code":32,"dataId":6,"value":1}],"etypeId":1,"params":[0,0,300,0,0,0,0,0],"price":0,"animationId":1,"wtypeId":16},
-{"id":160,"name":"\"Concussion\"","note":"<skillId:151>\n<offhandSkillId:154>\n<speedBoost:10>\n<notRefinementMaterial>\n<thisHit:280>","description":"No element, no edge, and no clever trick left to explain it away.\nPure force, which nothing in the world has ever learned to resist.","iconIndex":2586,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":10,"value":0}],"etypeId":1,"params":[0,0,520,0,0,0,0,0],"price":0,"animationId":1,"wtypeId":16},
-{"id":161,"name":"Skinning Hooks","note":"<skillId:161>\n<offhandSkillId:164>\n<speedBoost:5>\n<maxRefineCount:2>\n<maxRefinedTraits:2>\n<thisHit:50>\n<thisCri:6>","description":"Hooks for getting a hide off something that would rather have kept it.\nSlays beasts.","iconIndex":105,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":16,"value":0}],"etypeId":1,"params":[0,0,30,0,0,0,0,0],"price":500,"animationId":1,"wtypeId":17},
-{"id":162,"name":"Husk Splitters","note":"<skillId:161>\n<offhandSkillId:164>\n<speedBoost:5>\n<maxRefineCount:5>\n<maxRefinedTraits:3>\n<thisHit:110>\n<thisCri:8>","description":"The shell is the easy part. What is folded up inside it takes practice.\nSlays beasts and insects.","iconIndex":377,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":16,"value":0},{"code":31,"dataId":17,"value":0}],"etypeId":1,"params":[0,0,70,0,0,0,0,0],"price":2500,"animationId":1,"wtypeId":17},
-{"id":163,"name":"Underbelly Rippers","note":"<skillId:161>\n<offhandSkillId:164>\n<speedBoost:5>\n<maxRefineCount:8>\n<maxRefinedTraits:4>\n<thisHit:180>\n<thisCri:10>","description":"You will never get through the scales, so it is fortunate nothing is scaled underneath.\nSlays beasts, insects, and reptiles.","iconIndex":322,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":16,"value":0},{"code":31,"dataId":17,"value":0},{"code":31,"dataId":12,"value":0}],"etypeId":1,"params":[0,0,125,0,0,0,0,0],"price":10000,"animationId":1,"wtypeId":17},
-{"id":164,"name":"Marrow Reapers","note":"<skillId:161>\n<offhandSkillId:164>\n<speedBoost:5>\n<maxRefineCount:12>\n<maxRefinedTraits:5>\n<thisHit:260>\n<thisCri:12>","description":"It does not bleed and it does not tire, so stop trying to hurt it and take it apart instead.\nSlays beasts, insects, reptiles, and the undead.","iconIndex":321,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":16,"value":0},{"code":31,"dataId":17,"value":0},{"code":31,"dataId":12,"value":0},{"code":31,"dataId":11,"value":0}],"etypeId":1,"params":[0,0,195,0,0,0,0,0],"price":50000,"animationId":1,"wtypeId":17},
-{"id":165,"name":"Throat Finders","note":"<skillId:161>\n<offhandSkillId:164>\n<speedBoost:5>\n<maxRefineCount:18>\n<maxRefinedTraits:7>\n<thisHit:350>\n<thisCri:15>","description":"Armor covers most of a person. Most is not all, and the rest of it is up near the collar.\nSlays beasts, insects, reptiles, the undead, and humanoids.","iconIndex":380,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":16,"value":0},{"code":31,"dataId":17,"value":0},{"code":31,"dataId":12,"value":0},{"code":31,"dataId":11,"value":0},{"code":31,"dataId":18,"value":0}],"etypeId":1,"params":[0,0,280,0,0,0,0,0],"price":200000,"animationId":1,"wtypeId":17},
-{"id":166,"name":"Godflayers","note":"<skillId:161>\n<offhandSkillId:164>\n<speedBoost:5>\n<maxRefineCount:25>\n<maxRefinedTraits:10>\n<thisHit:450>\n<thisCri:18>","description":"There is no technique for this. There is only the decision to begin.\nSlays beasts, insects, reptiles, the undead, humanoids, and deities.","iconIndex":381,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":16,"value":0},{"code":31,"dataId":17,"value":0},{"code":31,"dataId":12,"value":0},{"code":31,"dataId":11,"value":0},{"code":31,"dataId":18,"value":0},{"code":31,"dataId":20,"value":0}],"etypeId":1,"params":[0,0,380,0,0,0,0,0],"price":750000,"animationId":1,"wtypeId":17},
-{"id":167,"name":"\"Brought Down\"","note":"<skillId:161>\n<offhandSkillId:164>\n<speedBoost:5>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:120>\n<thisCri:12>","description":"⭐ It was in the air. It is not in the air now.\nAnnihilates flying foes.","iconIndex":376,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":22,"value":0}],"etypeId":1,"params":[0,0,95,0,0,0,0,0],"price":0,"animationId":1,"wtypeId":17},
-{"id":168,"name":"\"Opened Up\"","note":"<skillId:161>\n<offhandSkillId:164>\n<speedBoost:5>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:250>\n<thisCri:16>","description":"⭐⭐ Whatever it was holding shut, it is not holding shut any longer.\nAnnihilates flying and shielded foes.","iconIndex":378,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":22,"value":0},{"code":31,"dataId":23,"value":0}],"etypeId":1,"params":[0,0,220,0,0,0,0,0],"price":0,"animationId":1,"wtypeId":17},
-{"id":169,"name":"\"Nemean's Talons\"","note":"<skillId:161>\n<offhandSkillId:164>\n<speedBoost:5>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:380>\n<thisCri:22>","description":"⭐⭐⭐ Its hide turned aside every blade ever forged. Its own claws did not.\nAnnihilates flying, shielded, and aural foes.","iconIndex":379,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":22,"value":0},{"code":31,"dataId":23,"value":0},{"code":31,"dataId":24,"value":0}],"etypeId":1,"params":[0,0,430,0,0,0,0,0],"price":0,"animationId":1,"wtypeId":17},
-{"id":170,"name":"\"Sparagmos\"","note":"<skillId:161>\n<offhandSkillId:164>\n<speedBoost:5>\n<notRefinementMaterial>\n<thisHit:600>\n<thisCri:30>","description":"Not a technique but a rite, performed with the hands, and performed until it is finished.\nSlays every kind of thing there is.","iconIndex":382,"traits":[{"code":31,"dataId":1,"value":0},{"code":31,"dataId":10,"value":0},{"code":31,"dataId":16,"value":0},{"code":31,"dataId":17,"value":0},{"code":31,"dataId":12,"value":0},{"code":31,"dataId":11,"value":0},{"code":31,"dataId":18,"value":0},{"code":31,"dataId":20,"value":0},{"code":31,"dataId":22,"value":0},{"code":31,"dataId":23,"value":0},{"code":31,"dataId":24,"value":0}],"etypeId":1,"params":[0,0,760,0,0,0,0,0],"price":0,"animationId":1,"wtypeId":17},
-{"id":171,"name":"Basic Arm","note":"<skillId:171>\n<offhandSkillId:174>\n<maxRefineCount:2>\n<maxRefinedTraits:2>\n<thisHit:20>","description":"A light mechanical enhancement for your arm, sold as-is and with no warranty.\nDisassembles constructs, may apply \\State[8](10%).","iconIndex":106,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":19,"value":0},{"code":32,"dataId":8,"value":0.1}],"etypeId":1,"params":[200,0,50,15,0,0,0,0],"price":1000,"animationId":1,"wtypeId":18},
-{"id":172,"name":"Heavy Arm","note":"<skillId:171>\n<offhandSkillId:174>\n<maxRefineCount:5>\n<maxRefinedTraits:3>\n<thisHit:45>","description":"Heavier, and therefore better, by the only metric that has ever really mattered.\nDisassembles constructs, may apply \\State[8](10%).","iconIndex":106,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":19,"value":0},{"code":32,"dataId":8,"value":0.1}],"etypeId":1,"params":[450,0,100,30,0,0,0,0],"price":5000,"animationId":1,"wtypeId":18},
-{"id":173,"name":"Hydraulic Press","note":"<skillId:171>\n<offhandSkillId:174>\n<maxRefineCount:8>\n<maxRefinedTraits:4>\n<thisHit:75>","description":"Rated for industrial use, which nobody has ever once interpreted as a restriction.\nDisassembles constructs, may apply \\State[8](10%).","iconIndex":106,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":19,"value":0},{"code":32,"dataId":8,"value":0.1}],"etypeId":1,"params":[800,0,175,55,0,0,0,0],"price":25000,"animationId":1,"wtypeId":18},
-{"id":174,"name":"Piledriver","note":"<skillId:171>\n<offhandSkillId:174>\n<maxRefineCount:12>\n<maxRefinedTraits:5>\n<thisHit:110>","description":"It drives piles. It has never been especially fussy about what counts as a pile.\nDisassembles constructs, may apply \\State[8](10%).","iconIndex":106,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":19,"value":0},{"code":32,"dataId":8,"value":0.1}],"etypeId":1,"params":[1300,0,280,95,0,0,0,0],"price":100000,"animationId":1,"wtypeId":18},
-{"id":175,"name":"Demolition Rig","note":"<skillId:171>\n<offhandSkillId:174>\n<maxRefineCount:18>\n<maxRefinedTraits:7>\n<thisHit:150>","description":"Condemned buildings and condemned people come down in much the same fashion.\nDisassembles constructs, may apply \\State[8](10%).","iconIndex":106,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":19,"value":0},{"code":32,"dataId":8,"value":0.1}],"etypeId":1,"params":[1900,0,415,145,0,0,0,0],"price":400000,"animationId":1,"wtypeId":18},
-{"id":176,"name":"Superstructure","note":"<skillId:171>\n<offhandSkillId:174>\n<maxRefineCount:25>\n<maxRefinedTraits:10>\n<thisHit:195>","description":"At some point the arm stopped being your attachment and you became its.\nDisassembles constructs, may apply \\State[8](10%).","iconIndex":106,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":19,"value":0},{"code":32,"dataId":8,"value":0.1}],"etypeId":1,"params":[2600,0,580,210,0,0,0,0],"price":999999,"animationId":1,"wtypeId":18},
-{"id":177,"name":"\"Meta Arm\"","note":"<skillId:171>\n<offhandSkillId:174>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:60>\n<stateDurationFlat:30>","description":"⭐ A cybernetic wonder, preloaded with some tutorials on kicking machine ass.\nDisassembles constructs, may apply \\State[8](25%), lengthens every state you apply by 0.5 seconds.","iconIndex":143,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":19,"value":0},{"code":32,"dataId":8,"value":0.25}],"etypeId":1,"params":[600,0,135,40,0,0,0,0],"price":0,"animationId":5,"wtypeId":18},
-{"id":178,"name":"\"Sybirtek Arm\"","note":"<skillId:171>\n<offhandSkillId:174>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:130>\n<stateDurationFlat:60>","description":"⭐⭐ A mechanical masterpiece, constructed by Sybirtek™ for your combat pleasure.\nDisassembles constructs, may apply \\State[8](25%), lengthens every state you apply by 1 second.","iconIndex":143,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":19,"value":0},{"code":32,"dataId":8,"value":0.25}],"etypeId":1,"params":[1600,0,340,115,0,0,0,0],"price":0,"animationId":5,"wtypeId":18},
-{"id":179,"name":"\"Talos\"","note":"<skillId:171>\n<offhandSkillId:174>\n<notRefinementBase>\n<notRefinementMaterial>\n<thisHit:220>\n<stateDurationFlat:90>","description":"⭐⭐⭐ The bronze sentry of Crete, who killed by taking hold and not letting go.\nDisassembles constructs, may apply \\State[8](25%), lengthens every state you apply by 1.5 seconds.","iconIndex":143,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":19,"value":0},{"code":32,"dataId":8,"value":0.25}],"etypeId":1,"params":[3000,0,675,250,0,0,0,0],"price":0,"animationId":5,"wtypeId":18},
-{"id":180,"name":"\"Tonnage\"","note":"<skillId:171>\n<offhandSkillId:174>\n<notRefinementMaterial>\n<thisHit:280>","description":"No mechanism, no trick, and no particular hurry about any of it.\nSimply a very great deal of weight, arriving.","iconIndex":144,"traits":[{"code":31,"dataId":3,"value":0},{"code":31,"dataId":10,"value":0},{"code":31,"dataId":19,"value":0},{"code":32,"dataId":8,"value":0.25}],"etypeId":1,"params":[3800,0,825,315,0,0,0,0],"price":0,"animationId":5,"wtypeId":18}
+  null,
+  {
+    "id": 1,
+    "name": "Tarnished Sword",
+    "note": "\u003cskillId:1\u003e\n\u003coffhandSkillId:4\u003e\n\u003cmaxRefineCount:2\u003e\n\u003cmaxRefinedTraits:2\u003e\n\u003cthisHit:10\u003e\n\u003cthisCri:2\u003e",
+    "description": "A dirty and dark-bladed sword.\nIt might've had some magical properties at some point, but definitely doesn't now.",
+    "iconIndex": 545,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      15,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 100,
+    "animationId": 6,
+    "wtypeId": 1
+  },
+  {
+    "id": 2,
+    "name": "Greyed Sword",
+    "note": "\u003cskillId:1\u003e\n\u003coffhandSkillId:4\u003e\n\u003cmaxRefineCount:5\u003e\n\u003cmaxRefinedTraits:3\u003e\n\u003cthisHit:20\u003e\n\u003cthisCri:8\u003e",
+    "description": "A darkened blade finally makes its appearance!\nImbued with \\element[9].",
+    "iconIndex": 1713,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 9,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      30,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 1000,
+    "animationId": 6,
+    "wtypeId": 1
+  },
+  {
+    "id": 3,
+    "name": "Dark Slash",
+    "note": "\u003cskillId:1\u003e\n\u003coffhandSkillId:4\u003e\n\u003cmaxRefineCount:8\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:65\u003e\n\u003cthisCri:15\u003e",
+    "description": "When forging swords with Noire, apparently they become rather sinister-looking.\nImbued with \\element[9], may slay causing \\State[1](1%) on-hit.",
+    "iconIndex": 578,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 9,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 1,
+        "value": 0.01
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      60,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 10000,
+    "animationId": 6,
+    "wtypeId": 1
+  },
+  {
+    "id": 4,
+    "name": "Nocturnal Blade",
+    "note": "\u003cskillId:1\u003e\n\u003coffhandSkillId:4\u003e\n\u003cmaxRefineCount:12\u003e\n\u003cmaxRefinedTraits:5\u003e\n\u003cthisHit:90\u003e\n\u003cthisCri:30\u003e",
+    "description": "Further upgrading the quality of Noire is starting to make the blade look like midnight.\nImbued with \\element[9], may slay causing \\State[1](2%) on-hit.",
+    "iconIndex": 1721,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 9,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 1,
+        "value": 0.02
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      90,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 50000,
+    "animationId": 6,
+    "wtypeId": 1
+  },
+  {
+    "id": 5,
+    "name": "Ecliptic Render",
+    "note": "\u003cskillId:1\u003e\n\u003coffhandSkillId:4\u003e\n\u003cmaxRefineCount:18\u003e\n\u003cmaxRefinedTraits:7\u003e\n\u003cthisHit:105\u003e\n\u003cthisCri:50\u003e",
+    "description": "The Noire has drunk so deeply that the blade now swallows what little light finds it.\nImbued with \\element[9], may slay causing \\State[1](3%) on-hit.",
+    "iconIndex": 1622,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 9,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 1,
+        "value": 0.03
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      135,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 175000,
+    "animationId": 6,
+    "wtypeId": 1
+  },
+  {
+    "id": 6,
+    "name": "Lunar Vengeance",
+    "note": "\u003cskillId:1\u003e\n\u003coffhandSkillId:4\u003e\n\u003cmaxRefineCount:25\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:125\u003e\n\u003cthisCri:80\u003e",
+    "description": "The darkness in its most natural habitat, the dark side of the moon.\nImbued with \\element[9], may slay causing \\State[1](4%) on-hit.",
+    "iconIndex": 1643,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 9,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 1,
+        "value": 0.04
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      190,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 500000,
+    "animationId": 6,
+    "wtypeId": 1
+  },
+  {
+    "id": 7,
+    "name": "\"Light Thrust\"",
+    "note": "\u003cskillId:1\u003e\n\u003coffhandSkillId:4\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:75\u003e\n\u003cthisCri:10\u003e",
+    "description": "⭐ An unusually glowy blade for a \"sword in the stone\" type of weapon.\nImbued with \\element[8], may purge causing \\State[1](2%) on-hit.",
+    "iconIndex": 560,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 8,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 1,
+        "value": 0.02
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      50,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 6,
+    "wtypeId": 1
+  },
+  {
+    "id": 8,
+    "name": "\"Sacred Spine\"",
+    "note": "\u003cskillId:1\u003e\n\u003coffhandSkillId:4\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:140\u003e\n\u003cthisCri:15\u003e",
+    "description": "⭐⭐ The glow of the blade appears to have sharpened the blade to a fine point.\nImbued with \\element[8], may purge causing \\State[1](4%) on-hit.",
+    "iconIndex": 562,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 8,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 1,
+        "value": 0.04
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      100,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 6,
+    "wtypeId": 1
+  },
+  {
+    "id": 9,
+    "name": "\"Claidheamh Soluis\"",
+    "note": "\u003cskillId:1\u003e\n\u003coffhandSkillId:4\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:200\u003e\n\u003cthisCri:25\u003e",
+    "description": "⭐⭐⭐ An ascended blade of pure energy, renowned for cleaving foes in twain.\nImbued with \\element[8], may purge causing \\State[1](6%) on-hit.",
+    "iconIndex": 1638,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 8,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 1,
+        "value": 0.06
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      225,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 6,
+    "wtypeId": 1
+  },
+  {
+    "id": 10,
+    "name": "\"The Corona\"",
+    "note": "\u003cskillId:1\u003e\n\u003coffhandSkillId:4\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:250\u003e\n\u003cthisCri:150\u003e",
+    "description": "\"Dark swallows the light; heaven opens, hell yawns wide;\nand the crown remains.\"",
+    "iconIndex": 1777,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      380,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 6,
+    "wtypeId": 1
+  },
+  {
+    "id": 11,
+    "name": "Whistling Claymore",
+    "note": "\u003cskillId:11\u003e\n\u003coffhandSkillId:14\u003e\n\u003cspeedBoost:-15\u003e\n\u003cmaxRefineCount:4\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:40\u003e\n\u003cthisCri:15\u003e",
+    "description": "It is very light- for a crappy claymore.\nWielded in both hands.",
+    "iconIndex": 1644,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      50,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 100,
+    "animationId": 6,
+    "wtypeId": 2
+  },
+  {
+    "id": 12,
+    "name": "Gusty Slasher",
+    "note": "\u003cskillId:11\u003e\n\u003coffhandSkillId:14\u003e\n\u003cspeedBoost:-15\u003e\n\u003cmaxRefineCount:10\u003e\n\u003cmaxRefinedTraits:6\u003e\n\u003cthisHit:60\u003e\n\u003cthisCri:30\u003e",
+    "description": "Forged with a nice chunk of verte, this sizeable slasher was born.\nImbued with \\element[6], wielded in both hands.",
+    "iconIndex": 513,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 6,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      90,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 1000,
+    "animationId": 6,
+    "wtypeId": 2
+  },
+  {
+    "id": 13,
+    "name": "Cyclone Sword",
+    "note": "\u003cskillId:11\u003e\n\u003coffhandSkillId:14\u003e\n\u003cspeedBoost:-15\u003e\n\u003cmaxRefineCount:16\u003e\n\u003cmaxRefinedTraits:8\u003e\n\u003cthisHit:100\u003e\n\u003cthisCri:40\u003e",
+    "description": "The power of the gale wraps this massive sword like a soft and delicate blanket.\nImbued with \\element[6], may apply \\State[11](25%) on-hit, wielded in both hands.",
+    "iconIndex": 514,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 6,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 11,
+        "value": 0.25
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      150,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 10000,
+    "animationId": 6,
+    "wtypeId": 2
+  },
+  {
+    "id": 14,
+    "name": "Mountaintop Chopper",
+    "note": "\u003cskillId:11\u003e\n\u003coffhandSkillId:14\u003e\n\u003cspeedBoost:-15\u003e\n\u003cmaxRefineCount:24\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:170\u003e\n\u003cthisCri:60\u003e",
+    "description": "Empowered with the blessing of the mountain winds, you still aren't very fast while holding this.\nImbued with \\element[6], may apply \\State[11](50%) on-hit, wielded in both hands.",
+    "iconIndex": 516,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 6,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 11,
+        "value": 0.5
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      210,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 50000,
+    "animationId": 6,
+    "wtypeId": 2
+  },
+  {
+    "id": 15,
+    "name": "Hurricane Hacker",
+    "note": "\u003cskillId:11\u003e\n\u003coffhandSkillId:14\u003e\n\u003cspeedBoost:-15\u003e\n\u003cmaxRefineCount:36\u003e\n\u003cmaxRefinedTraits:14\u003e\n\u003cthisHit:250\u003e\n\u003cthisCri:100\u003e",
+    "description": "A mighty hurricane RAGES inside this vicious claymore, theoretically.\nImbued with \\element[6], may apply \\State[11](75%) on-hit, wielded in both hands.",
+    "iconIndex": 1556,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 6,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 11,
+        "value": 0.75
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      280,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 175000,
+    "animationId": 6,
+    "wtypeId": 2
+  },
+  {
+    "id": 16,
+    "name": "Sundering Cleaver",
+    "note": "\u003cskillId:11\u003e\n\u003coffhandSkillId:14\u003e\n\u003cspeedBoost:-15\u003e\n\u003cmaxRefineCount:50\u003e\n\u003cmaxRefinedTraits:20\u003e\n\u003cthisHit:320\u003e\n\u003cthisCri:140\u003e",
+    "description": "An enormous claymore whose every slash cleaves the skies (and your foes defenses) asunder.\nImbued with \\element[6], applies \\State[11] on-hit, wielded in both hands.",
+    "iconIndex": 1653,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 6,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 11,
+        "value": 1
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      350,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 500000,
+    "animationId": 6,
+    "wtypeId": 2
+  },
+  {
+    "id": 17,
+    "name": "\"Colossus\"",
+    "note": "\u003cskillId:11\u003e\n\u003coffhandSkillId:14\u003e\n\u003cspeedBoost:-15\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:100\u003e\n\u003cthisCri:30\u003e",
+    "description": "⭐ Are you trying to compensate by wielding this monstrously large chunk of rock?\nImbued with \\element[7], may apply \\State[12](50%) on-hit, wielded in both hands.",
+    "iconIndex": 546,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 7,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 12,
+        "value": 0.5
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      120,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 6,
+    "wtypeId": 2
+  },
+  {
+    "id": 18,
+    "name": "\"Juggernaut\"",
+    "note": "\u003cskillId:11\u003e\n\u003coffhandSkillId:14\u003e\n\u003cspeedBoost:-15\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:200\u003e\n\u003cthisCri:80\u003e",
+    "description": "⭐⭐ A colossal weapon reinforced with the finest ores.\nImbued with \\element[7], applies \\State[12] on-hit, wielded in both hands.",
+    "iconIndex": 1646,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 7,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 12,
+        "value": 1
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      250,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 6,
+    "wtypeId": 2
+  },
+  {
+    "id": 19,
+    "name": "\"Lævateinn\"",
+    "note": "\u003cskillId:11\u003e\n\u003coffhandSkillId:14\u003e\n\u003cspeedBoost:-15\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:380\u003e\n\u003cthisCri:160\u003e",
+    "description": "⭐⭐⭐ An ascended blade of dragon-slaying might, able to take down any reptile around!\nImbued with \\element[7], applies \\State[12] on-hit, wielded in both hands.",
+    "iconIndex": 1641,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 7,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 12,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 12,
+        "value": 1
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      550,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 6,
+    "wtypeId": 2
+  },
+  {
+    "id": 20,
+    "name": "\"Aeolian\"",
+    "note": "\u003cskillId:11\u003e\n\u003coffhandSkillId:14\u003e\n\u003cspeedBoost:-15\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:450\u003e\n\u003cthisCri:250\u003e",
+    "description": "The gale cannot be stopped, the mountain cannot be moved, and yet the canyon exists.\nWielded in both hands.",
+    "iconIndex": 1621,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      720,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 6,
+    "wtypeId": 2
+  },
+  {
+    "id": 21,
+    "name": "Rain Edge",
+    "note": "\u003cskillId:21\u003e\n\u003cspeedBoost:10\u003e\n\u003cmaxRefineCount:2\u003e\n\u003cmaxRefinedTraits:2\u003e\n\u003cthisHit:15\u003e\n\u003cthisCri:4\u003e\n\u003cthisGrd:12\u003e",
+    "description": "A blade that has taken on a much lighter form, and looks pretty slick now.\nImbued with \"Liquid\", may apply \\State[10](10%) on-hit, designed to be dual-wielded with another weapon.",
+    "iconIndex": 592,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 5,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 10,
+        "value": 0.1
+      },
+      {
+        "code": 55,
+        "dataId": 1,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      10,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 100,
+    "animationId": 6,
+    "wtypeId": 3
+  },
+  {
+    "id": 22,
+    "name": "Blaze Edge",
+    "note": "\u003cskillId:21\u003e\n\u003cspeedBoost:12\u003e\n\u003cmaxRefineCount:5\u003e\n\u003cmaxRefinedTraits:3\u003e\n\u003cthisHit:18\u003e\n\u003cthisCri:12\u003e\n\u003cthisGrd:15\u003e",
+    "description": "A blade that is too hot to touch! It seems forging with rouge has a heat-like elemental effect.\nImbued with \"Heat\", may apply \\State[9](10%) on-hit, designed to be dual-wielded with another weapon.",
+    "iconIndex": 528,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 4,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 9,
+        "value": 0.1
+      },
+      {
+        "code": 55,
+        "dataId": 1,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      25,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 2500,
+    "animationId": 6,
+    "wtypeId": 3
+  },
+  {
+    "id": 23,
+    "name": "Vulcan Edge",
+    "note": "\u003cskillId:21\u003e\n\u003cspeedBoost:15\u003e\n\u003cmaxRefineCount:8\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:25\u003e\n\u003cthisCri:22\u003e\n\u003cthisGrd:20\u003e",
+    "description": "A ruthless blade powered by the flames of the finest Rouge.\nImbued with \"Heat\", may apply \\State[9](20%) on-hit, designed to be dual-wielded with another weapon.",
+    "iconIndex": 529,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 4,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 9,
+        "value": 0.2
+      },
+      {
+        "code": 55,
+        "dataId": 1,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      45,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 250000,
+    "animationId": 6,
+    "wtypeId": 3
+  },
+  {
+    "id": 24,
+    "name": "Torrent Edge",
+    "note": "\u003cskillId:21\u003e\n\u003cspeedBoost:18\u003e\n\u003cmaxRefineCount:12\u003e\n\u003cmaxRefinedTraits:5\u003e\n\u003cthisHit:55\u003e\n\u003cthisCri:24\u003e\n\u003cthisGrd:35\u003e",
+    "description": "A gorgeous edge that is capable of a torrent of strikes in no time.\nImbued with \"Liquid\", may apply \\State[10](20%) on-hit, designed to be dual-wielded with another weapon.",
+    "iconIndex": 593,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 5,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 10,
+        "value": 0.2
+      },
+      {
+        "code": 55,
+        "dataId": 1,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      65,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 500000,
+    "animationId": 6,
+    "wtypeId": 3
+  },
+  {
+    "id": 25,
+    "name": "Inferno Edge",
+    "note": "\u003cskillId:21\u003e\n\u003cspeedBoost:22\u003e\n\u003cmaxRefineCount:18\u003e\n\u003cmaxRefinedTraits:7\u003e\n\u003cthisHit:60\u003e\n\u003cthisCri:38\u003e\n\u003cthisGrd:38\u003e",
+    "description": "A blade whose edge never cools, forged from the most volatile rouge obtainable.\nImbued with \"Heat\", may apply \\State[9](25%) on-hit, designed to be dual-wielded with another weapon.",
+    "iconIndex": 530,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 4,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 9,
+        "value": 0.25
+      },
+      {
+        "code": 55,
+        "dataId": 1,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      85,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 750000,
+    "animationId": 6,
+    "wtypeId": 3
+  },
+  {
+    "id": 26,
+    "name": "Maelstrom Edge",
+    "note": "\u003cskillId:21\u003e\n\u003cspeedBoost:26\u003e\n\u003cmaxRefineCount:25\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:85\u003e\n\u003cthisCri:40\u003e\n\u003cthisGrd:52\u003e",
+    "description": "A blade that moves like a current with a will of its own, pulling every strike into the next.\nImbued with \"Liquid\", may apply \\State[10](25%) on-hit, designed to be dual-wielded with another weapon.",
+    "iconIndex": 594,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 5,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 10,
+        "value": 0.25
+      },
+      {
+        "code": 55,
+        "dataId": 1,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      105,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 999999,
+    "animationId": 6,
+    "wtypeId": 3
+  },
+  {
+    "id": 27,
+    "name": "\"Agility\"",
+    "note": "\u003cskillId:21\u003e\n\u003cspeedBoost:20\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:30\u003e\n\u003cthisGrd:30\u003e",
+    "description": "⭐ Supposedly the embodiment of agility, and does indeed improve hit and parry chances.\nDesigned to be dual-wielded with another weapon.",
+    "iconIndex": 1718,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 55,
+        "dataId": 1,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      40,
+      0,
+      0,
+      0,
+      10,
+      0
+    ],
+    "price": 0,
+    "animationId": 6,
+    "wtypeId": 3
+  },
+  {
+    "id": 28,
+    "name": "\"Swiftness\"",
+    "note": "\u003cskillId:21\u003e\n\u003cspeedBoost:25\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:60\u003e\n\u003cthisGrd:60\u003e",
+    "description": "⭐⭐ A masterfully refined upgrade to agility, this blade truly is swiftness incarnate.\nDesigned to be dual-wielded with another weapon.",
+    "iconIndex": 1632,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 55,
+        "dataId": 1,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      75,
+      0,
+      0,
+      0,
+      20,
+      0
+    ],
+    "price": 0,
+    "animationId": 6,
+    "wtypeId": 3
+  },
+  {
+    "id": 29,
+    "name": "\"Hrunting\"",
+    "note": "\u003cskillId:21\u003e\n\u003cspeedBoost:30\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:100\u003e\n\u003cthisGrd:100\u003e",
+    "description": "⭐⭐⭐ An ascended blade that drips with a lethal poison that will seal healing of any kind.\nMay apply \\State[14](20%) on-hit, designed to be dual-wielded with another weapon.",
+    "iconIndex": 1654,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 14,
+        "value": 0.2
+      },
+      {
+        "code": 55,
+        "dataId": 1,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      150,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 6,
+    "wtypeId": 3
+  },
+  {
+    "id": 30,
+    "name": "\"Gemini\"",
+    "note": "\u003cskillId:21\u003e\n\u003cspeedBoost:35\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:150\u003e\n\u003cthisCri:90\u003e\n\u003cthisGrd:90\u003e",
+    "description": "Heat and current, quenched into one steel that promptly decided to be two.\nAlways found as a pair, and always wielded as one.",
+    "iconIndex": 609,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 55,
+        "dataId": 1,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      210,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 6,
+    "wtypeId": 3
+  },
+  {
+    "id": 31,
+    "name": "Poker",
+    "note": "\u003cskillId:31\u003e\n\u003coffhandSkillId:34\u003e\n\u003cspeedBoost:5\u003e\n\u003cmaxRefineCount:4\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003ccdmBuffPlus:[50]\u003e\n\u003cthisHit:30\u003e\n\u003cthisCri:6\u003e",
+    "description": "While it is technically a spear-class weapon, this is still just a fucking stick.\nWielded in both hands.",
+    "iconIndex": 791,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      5,
+      0,
+      0,
+      0,
+      10,
+      0
+    ],
+    "price": 100,
+    "animationId": 11,
+    "wtypeId": 4
+  },
+  {
+    "id": 32,
+    "name": "Piercer",
+    "note": "\u003cskillId:31\u003e\n\u003coffhandSkillId:34\u003e\n\u003cspeedBoost:5\u003e\n\u003cmaxRefineCount:10\u003e\n\u003cmaxRefinedTraits:6\u003e\n\u003ccdmBuffPlus:[75]\u003e\n\u003cthisHit:50\u003e\n\u003cthisCri:12\u003e",
+    "description": "Your standard-issue soldier's iron spear.\nWielded in both hands.",
+    "iconIndex": 107,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      10,
+      0,
+      0,
+      0,
+      25,
+      0
+    ],
+    "price": 1000,
+    "animationId": 11,
+    "wtypeId": 4
+  },
+  {
+    "id": 33,
+    "name": "Perforator",
+    "note": "\u003cskillId:31\u003e\n\u003coffhandSkillId:34\u003e\n\u003cspeedBoost:10\u003e\n\u003cmaxRefineCount:16\u003e\n\u003cmaxRefinedTraits:8\u003e\n\u003ccdmBuffPlus:[125]\u003e\n\u003cthisHit:70\u003e\n\u003cthisCri:25\u003e",
+    "description": "Punches clean holes through things that would rather remain whole.\nWielded in both hands.",
+    "iconIndex": 515,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      40,
+      0,
+      0,
+      0,
+      75,
+      0
+    ],
+    "price": 25000,
+    "animationId": 11,
+    "wtypeId": 4
+  },
+  {
+    "id": 34,
+    "name": "Transfixer",
+    "note": "\u003cskillId:31\u003e\n\u003coffhandSkillId:34\u003e\n\u003cspeedBoost:10\u003e\n\u003cmaxRefineCount:24\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003ccdmBuffPlus:[150]\u003e\n\u003cthisHit:90\u003e\n\u003cthisCri:30\u003e",
+    "description": "Long enough to go all the way through, and it usually does.\nWielded in both hands, may apply \\State[15](5%) on-hit.",
+    "iconIndex": 435,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 15,
+        "value": 0.05
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      100,
+      0,
+      0,
+      0,
+      150,
+      0
+    ],
+    "price": 100000,
+    "animationId": 11,
+    "wtypeId": 4
+  },
+  {
+    "id": 35,
+    "name": "Eviscerator",
+    "note": "\u003cskillId:31\u003e\n\u003coffhandSkillId:34\u003e\n\u003cspeedBoost:15\u003e\n\u003cmaxRefineCount:36\u003e\n\u003cmaxRefinedTraits:14\u003e\n\u003ccdmBuffPlus:[200]\u003e\n\u003cthisHit:120\u003e\n\u003cthisCri:50\u003e",
+    "description": "One twist of the shaft leaves a hole that will not close.\nWielded in both hands, may apply \\State[15](10%) on-hit.",
+    "iconIndex": 410,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 15,
+        "value": 0.1
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      120,
+      0,
+      0,
+      0,
+      200,
+      0
+    ],
+    "price": 500000,
+    "animationId": 11,
+    "wtypeId": 4
+  },
+  {
+    "id": 36,
+    "name": "Bloodletter",
+    "note": "\u003cskillId:31\u003e\n\u003coffhandSkillId:34\u003e\n\u003cspeedBoost:15\u003e\n\u003cmaxRefineCount:50\u003e\n\u003cmaxRefinedTraits:20\u003e\n\u003ccdmBuffPlus:[250]\u003e\n\u003cthisHit:150\u003e\n\u003cthisCri:65\u003e",
+    "description": "Its barbs are angled to open on the way out, not the way in.\nWielded in both hands, may apply \\State[15](20%) on-hit.",
+    "iconIndex": 410,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 15,
+        "value": 0.2
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      160,
+      0,
+      0,
+      0,
+      260,
+      0
+    ],
+    "price": 999999,
+    "animationId": 11,
+    "wtypeId": 4
+  },
+  {
+    "id": 37,
+    "name": "\"Akai Supeeya\"",
+    "note": "\u003cskillId:31\u003e\n\u003coffhandSkillId:34\u003e\n\u003cspeedBoost:10\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003ccdmBuffPlus:[150]\u003e\n\u003cthisHit:70\u003e\n\u003cthisCri:15\u003e",
+    "description": "⭐ It might be... from a foreign land... but it also might be a knock-off... At least it looks flashy?\nWielded in both hands, may apply \\State[15](25%) on-hit.",
+    "iconIndex": 409,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 15,
+        "value": 0.25
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      25,
+      0,
+      0,
+      0,
+      40,
+      0
+    ],
+    "price": 0,
+    "animationId": 12,
+    "wtypeId": 4
+  },
+  {
+    "id": 38,
+    "name": "\"Crimson Stabber\"",
+    "note": "\u003cskillId:31\u003e\n\u003coffhandSkillId:34\u003e\n\u003cspeedBoost:15\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003ccdmBuffPlus:[150]\u003e\n\u003cthisHit:110\u003e\n\u003cthisCri:40\u003e",
+    "description": "⭐⭐ The lethality of this blade is unmistakable. Blood everywhere.\nWielded in both hands, may apply \\State[15](50%) on-hit.",
+    "iconIndex": 580,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 15,
+        "value": 0.5
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      110,
+      0,
+      0,
+      0,
+      175,
+      6
+    ],
+    "price": 0,
+    "animationId": 12,
+    "wtypeId": 4
+  },
+  {
+    "id": 39,
+    "name": "\"Rhongomyniad\"",
+    "note": "\u003cskillId:31\u003e\n\u003coffhandSkillId:34\u003e\n\u003cspeedBoost:20\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003ccdmBuffPlus:[400]\u003e\n\u003cthisHit:150\u003e\n\u003cthisCri:80\u003e",
+    "description": "⭐⭐⭐ An ascended spear that is makes you bleed just by looking at it.\nWielded in both hands, applies \\State[15] on-hit.",
+    "iconIndex": 582,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 15,
+        "value": 1
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      220,
+      0,
+      0,
+      0,
+      300,
+      6
+    ],
+    "price": 0,
+    "animationId": 12,
+    "wtypeId": 4
+  },
+  {
+    "id": 40,
+    "name": "\"Ichor\"",
+    "note": "\u003cskillId:31\u003e\n\u003coffhandSkillId:34\u003e\n\u003cspeedBoost:25\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:300\u003e\n\u003cthisCri:180\u003e",
+    "description": "They say that gods do not bleed; this went looking anyway.\nWielded in both hands.",
+    "iconIndex": 582,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      300,
+      0,
+      0,
+      0,
+      480,
+      0
+    ],
+    "price": 0,
+    "animationId": 12,
+    "wtypeId": 4
+  },
+  {
+    "id": 41,
+    "name": "Basher",
+    "note": "\u003cskillId:41\u003e\n\u003coffhandSkillId:45\u003e\n\u003cmaxRefineCount:4\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003ccdmBuffPlus:[20]\u003e\n\u003cthisHit:60\u003e\n\u003cthisCri:5\u003e",
+    "description": "Though this is classified as a \"spear\", it is rather more a ball on a stick.\nWielded in both hands, may apply \\State[8](5%) on-hit.",
+    "iconIndex": 1753,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.05
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      5,
+      0,
+      15,
+      15,
+      0,
+      0
+    ],
+    "price": 1000,
+    "animationId": 1,
+    "wtypeId": 5
+  },
+  {
+    "id": 42,
+    "name": "Smasher",
+    "note": "\u003cskillId:41\u003e\n\u003coffhandSkillId:45\u003e\n\u003cmaxRefineCount:10\u003e\n\u003cmaxRefinedTraits:6\u003e\n\u003ccdmBuffPlus:[40]\u003e\n\u003cthisHit:100\u003e\n\u003cthisCri:15\u003e",
+    "description": "We aren't getting any closer, but this absolutely will smash some skulls.\nWielded in both hands, may apply \\State[8](5%) on-hit.",
+    "iconIndex": 1357,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.05
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      20,
+      0,
+      50,
+      50,
+      0,
+      0
+    ],
+    "price": 25000,
+    "animationId": 1,
+    "wtypeId": 5
+  },
+  {
+    "id": 43,
+    "name": "Flasher",
+    "note": "\u003cskillId:41\u003e\n\u003coffhandSkillId:45\u003e\n\u003cmaxRefineCount:16\u003e\n\u003cmaxRefinedTraits:8\u003e\n\u003ccdmBuffPlus:[50]\u003e\n\u003cthisHit:140\u003e\n\u003cthisCri:20\u003e",
+    "description": "A flashy and fabulously smashtastic weapon for bashing your foes.\nWielded in both hands, may apply \\State[8](5%) on-hit.",
+    "iconIndex": 425,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.05
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      25,
+      0,
+      85,
+      85,
+      0,
+      0
+    ],
+    "price": 100000,
+    "animationId": 1,
+    "wtypeId": 5
+  },
+  {
+    "id": 44,
+    "name": "Clasher",
+    "note": "\u003cskillId:41\u003e\n\u003coffhandSkillId:45\u003e\n\u003cmaxRefineCount:24\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003ccdmBuffPlus:[80]\u003e\n\u003cthisHit:260\u003e\n\u003cthisCri:35\u003e",
+    "description": "A deadly and dangerous \"spear\", far and beyond something to poke with, just shove it at them.\nWielded in both hands, may apply \\State[8](5%) on-hit.",
+    "iconIndex": 426,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.05
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      40,
+      0,
+      110,
+      110,
+      0,
+      0
+    ],
+    "price": 500000,
+    "animationId": 1,
+    "wtypeId": 5
+  },
+  {
+    "id": 45,
+    "name": "Thrasher",
+    "note": "\u003cskillId:41\u003e\n\u003coffhandSkillId:45\u003e\n\u003cmaxRefineCount:36\u003e\n\u003cmaxRefinedTraits:14\u003e\n\u003ccdmBuffPlus:[110]\u003e\n\u003cthisHit:340\u003e\n\u003cthisCri:45\u003e",
+    "description": "Whatever poking this could do was abandoned somewhere around the third swing.\nWielded in both hands, may apply \\State[8](5%) on-hit.",
+    "iconIndex": 425,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.05
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      55,
+      0,
+      145,
+      145,
+      0,
+      0
+    ],
+    "price": 750000,
+    "animationId": 1,
+    "wtypeId": 5
+  },
+  {
+    "id": 46,
+    "name": "Crasher",
+    "note": "\u003cskillId:41\u003e\n\u003coffhandSkillId:45\u003e\n\u003cmaxRefineCount:50\u003e\n\u003cmaxRefinedTraits:20\u003e\n\u003ccdmBuffPlus:[150]\u003e\n\u003cthisHit:420\u003e\n\u003cthisCri:60\u003e",
+    "description": "Still filed under \"spear\", and at this point that is purely a paperwork problem.\nWielded in both hands, may apply \\State[8](5%) on-hit.",
+    "iconIndex": 426,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.05
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      75,
+      0,
+      185,
+      185,
+      0,
+      0
+    ],
+    "price": 999999,
+    "animationId": 1,
+    "wtypeId": 5
+  },
+  {
+    "id": 47,
+    "name": "\"Concussivity\"",
+    "note": "\u003cskillId:41\u003e\n\u003coffhandSkillId:45\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003ccdmBuffPlus:[40]\u003e\n\u003cthisHit:70\u003e\n\u003cthisCri:10\u003e",
+    "description": "⭐ At this point, we aren't even trying to hide the lack of spear-ness.\nImbued with \"Ground\", may apply \\State[12](25%) and \\State[8](5%) on-hit, wielded in both hands.",
+    "iconIndex": 424,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 7,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 12,
+        "value": 0.25
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.05
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      23,
+      0,
+      60,
+      60,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 12,
+    "wtypeId": 5
+  },
+  {
+    "id": 48,
+    "name": "\"Ground Pounder\"",
+    "note": "\u003cskillId:41\u003e\n\u003coffhandSkillId:45\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003ccdmBuffPlus:[70]\u003e\n\u003cthisHit:225\u003e\n\u003cthisCri:25\u003e",
+    "description": "⭐⭐ A massive hammer designed for crushing skulls- exactly as you aim to do.\nImbued with \"Ground\", may apply \\State[12](50%) on-hit and \\State[8](10%) on-hit, wielded in both hands.",
+    "iconIndex": 547,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 7,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 12,
+        "value": 0.5
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.1
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      50,
+      0,
+      140,
+      140,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 12,
+    "wtypeId": 5
+  },
+  {
+    "id": 49,
+    "name": "\"Daedalus\"",
+    "note": "\u003cskillId:41\u003e\n\u003coffhandSkillId:45\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003ccdmBuffPlus:[100]\u003e\n\u003cthisHit:350\u003e\n\u003cthisCri:40\u003e",
+    "description": "⭐⭐⭐ An ascended smashing tool, crafted by a legendary smith of unparalleled skill.\nImbued with \"Ground\", applies \\State[12] and maybe \\State[8](15%) on-hit, wielded in both hands, destroys shielded foes.",
+    "iconIndex": 1626,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 7,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 23,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 12,
+        "value": 1
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.15
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      100,
+      0,
+      200,
+      200,
+      0,
+      6
+    ],
+    "price": 0,
+    "animationId": 12,
+    "wtypeId": 5
+  },
+  {
+    "id": 50,
+    "name": "\"Seismos\"",
+    "note": "\u003cskillId:41\u003e\n\u003coffhandSkillId:45\u003e\n\u003cnotRefinementMaterial\u003e\n\u003ccdmBuffPlus:[200]\u003e\n\u003cthisHit:500\u003e\n\u003cthisCri:80\u003e",
+    "description": "The ground does not break where it is struck; it breaks everywhere else.\nWielded in both hands.",
+    "iconIndex": 1626,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      150,
+      0,
+      370,
+      370,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 12,
+    "wtypeId": 5
+  },
+  {
+    "id": 51,
+    "name": "Floppy Dart",
+    "note": "\u003cskillId:51\u003e\n\u003coffhandSkillId:53\u003e\n\u003cspeedBoost:15\u003e\n\u003cmaxRefineCount:2\u003e\n\u003cmaxRefinedTraits:2\u003e\n\u003ccdmBuffPlus:[50]\u003e\n\u003cthisHit:10\u003e\n\u003cthisCri:30\u003e",
+    "description": "The shaft has more give in it than anyone would like, but it still lands point-first. Usually.",
+    "iconIndex": 408,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      20,
+      0,
+      0,
+      0,
+      5,
+      0
+    ],
+    "price": 1000,
+    "animationId": 11,
+    "wtypeId": 6
+  },
+  {
+    "id": 52,
+    "name": "Whaling Harpoon",
+    "note": "\u003cskillId:51\u003e\n\u003coffhandSkillId:53\u003e\n\u003cspeedBoost:15\u003e\n\u003cmaxRefineCount:5\u003e\n\u003cmaxRefinedTraits:3\u003e\n\u003ccdmBuffPlus:[70]\u003e\n\u003cthisHit:40\u003e\n\u003cthisCri:60\u003e",
+    "description": "An excellent harpoon that was used in ancient times to puncture whale hide.",
+    "iconIndex": 1634,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      70,
+      0,
+      0,
+      0,
+      15,
+      0
+    ],
+    "price": 25000,
+    "animationId": 11,
+    "wtypeId": 6
+  },
+  {
+    "id": 53,
+    "name": "Kaboom Needle",
+    "note": "\u003cskillId:51\u003e\n\u003coffhandSkillId:53\u003e\n\u003cspeedBoost:20\u003e\n\u003cmaxRefineCount:8\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003ccdmBuffPlus:[80]\u003e\n\u003cthisHit:60\u003e\n\u003cthisCri:75\u003e",
+    "description": "While sharp spears are great, exploding spears are typically even greater.",
+    "iconIndex": 502,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      115,
+      0,
+      0,
+      0,
+      20,
+      0
+    ],
+    "price": 50000,
+    "animationId": 11,
+    "wtypeId": 6
+  },
+  {
+    "id": 54,
+    "name": "Harisakeru",
+    "note": "\u003cskillId:51\u003e\n\u003coffhandSkillId:53\u003e\n\u003cspeedBoost:20\u003e\n\u003cmaxRefineCount:12\u003e\n\u003cmaxRefinedTraits:5\u003e\n\u003ccdmBuffPlus:[100]\u003e\n\u003cthisHit:80\u003e\n\u003cthisCri:120\u003e",
+    "description": "Exacerbating explosive spears leads to super deadly and explosive spears.",
+    "iconIndex": 1629,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      200,
+      0,
+      0,
+      0,
+      40,
+      0
+    ],
+    "price": 500000,
+    "animationId": 11,
+    "wtypeId": 6
+  },
+  {
+    "id": 55,
+    "name": "Pilum",
+    "note": "\u003cskillId:51\u003e\n\u003coffhandSkillId:53\u003e\n\u003cspeedBoost:20\u003e\n\u003cmaxRefineCount:18\u003e\n\u003cmaxRefinedTraits:7\u003e\n\u003ccdmBuffPlus:[130]\u003e\n\u003cthisHit:110\u003e\n\u003cthisCri:150\u003e",
+    "description": "Its shank is meant to bend on impact, so that pulling it back out is somebody else's problem.",
+    "iconIndex": 502,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      270,
+      0,
+      0,
+      0,
+      55,
+      0
+    ],
+    "price": 750000,
+    "animationId": 11,
+    "wtypeId": 6
+  },
+  {
+    "id": 56,
+    "name": "Shrike",
+    "note": "\u003cskillId:51\u003e\n\u003coffhandSkillId:53\u003e\n\u003cspeedBoost:25\u003e\n\u003cmaxRefineCount:25\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003ccdmBuffPlus:[160]\u003e\n\u003cthisHit:140\u003e\n\u003cthisCri:185\u003e",
+    "description": "Named for the bird that leaves what it catches hanging on a thorn, still fresh.",
+    "iconIndex": 1629,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      350,
+      0,
+      0,
+      0,
+      70,
+      0
+    ],
+    "price": 999999,
+    "animationId": 11,
+    "wtypeId": 6
+  },
+  {
+    "id": 57,
+    "name": "\"Fish Eater\"",
+    "note": "\u003cskillId:51\u003e\n\u003coffhandSkillId:53\u003e\n\u003cspeedBoost:15\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003ccdmBuffPlus:[100]\u003e\n\u003cthisHit:30\u003e\n\u003cthisCri:50\u003e",
+    "description": "⭐ Excellent at piercing any type of aquatic animal thanks to its razor sharp point.",
+    "iconIndex": 878,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      75,
+      0,
+      25,
+      0,
+      18,
+      0
+    ],
+    "price": 0,
+    "animationId": 12,
+    "wtypeId": 6
+  },
+  {
+    "id": 58,
+    "name": "\"Sauroter\"",
+    "note": "\u003cskillId:51\u003e\n\u003coffhandSkillId:53\u003e\n\u003cspeedBoost:20\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003ccdmBuffPlus:[125]\u003e\n\u003cthisHit:75\u003e\n\u003cthisCri:100\u003e",
+    "description": "⭐⭐ The addition of serration enables slaying both aquatic and reptiles effortlessly.",
+    "iconIndex": 879,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 12,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      225,
+      0,
+      100,
+      0,
+      50,
+      0
+    ],
+    "price": 0,
+    "animationId": 12,
+    "wtypeId": 6
+  },
+  {
+    "id": 59,
+    "name": "\"Vel\"",
+    "note": "\u003cskillId:51\u003e\n\u003coffhandSkillId:53\u003e\n\u003cspeedBoost:25\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003ccdmBuffPlus:[150]\u003e\n\u003cthisHit:100\u003e\n\u003cthisCri:150\u003e",
+    "description": "⭐⭐⭐ An ascended javelin said to pierce anything, including aquatics, reptiles, and deities.",
+    "iconIndex": 1630,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 12,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 20,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      500,
+      0,
+      200,
+      0,
+      100,
+      0
+    ],
+    "price": 0,
+    "animationId": 12,
+    "wtypeId": 6
+  },
+  {
+    "id": 60,
+    "name": "\"Stigmata\"",
+    "note": "\u003cskillId:51\u003e\n\u003coffhandSkillId:53\u003e\n\u003cspeedBoost:30\u003e\n\u003cnotRefinementMaterial\u003e\n\u003ccdmBuffPlus:[200]\u003e\n\u003cthisHit:200\u003e\n\u003cthisCri:250\u003e",
+    "description": "Every hole it leaves stays open, and they all come due at once.",
+    "iconIndex": 1630,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      600,
+      0,
+      0,
+      0,
+      120,
+      0
+    ],
+    "price": 0,
+    "animationId": 12,
+    "wtypeId": 6
+  },
+  {
+    "id": 61,
+    "name": "Zip Gun",
+    "note": "\u003cskillId:61\u003e\n\u003coffhandSkillId:64\u003e\n\u003cmaxRefineCount:2\u003e\n\u003cmaxRefinedTraits:2\u003e\n\u003cthisHit:20\u003e\n\u003cthisCri:10\u003e\n\u003cthisTrg:2\u003e",
+    "description": "A pipe, a nail, and a rubber band. It fires about as well as that sounds,\nwhich is to say it is a tier-1 weapon.",
+    "iconIndex": 104,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      10,
+      0,
+      0,
+      0,
+      0,
+      10
+    ],
+    "price": 100,
+    "animationId": 125,
+    "wtypeId": 7
+  },
+  {
+    "id": 62,
+    "name": "Beretta",
+    "note": "\u003cskillId:61\u003e\n\u003coffhandSkillId:64\u003e\n\u003cmaxRefineCount:5\u003e\n\u003cmaxRefinedTraits:3\u003e\n\u003cthisHit:30\u003e\n\u003cthisCri:15\u003e\n\u003cthisTrg:2\u003e",
+    "description": "A standard everyday pistol.\nShoots bullets, in case you were unaware.",
+    "iconIndex": 2518,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      15,
+      0,
+      0,
+      0,
+      0,
+      15
+    ],
+    "price": 1000,
+    "animationId": 125,
+    "wtypeId": 7
+  },
+  {
+    "id": 63,
+    "name": "Magnum",
+    "note": "\u003cskillId:61\u003e\n\u003coffhandSkillId:64\u003e\n\u003cmaxRefineCount:8\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:40\u003e\n\u003cthisCri:25\u003e\n\u003cthisTrg:3\u003e",
+    "description": "A magnum, the king of classic pistols.\nFires with a over-compensating BANG.",
+    "iconIndex": 2515,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      25,
+      0,
+      0,
+      0,
+      0,
+      25
+    ],
+    "price": 25000,
+    "animationId": 125,
+    "wtypeId": 7
+  },
+  {
+    "id": 64,
+    "name": "Deagle",
+    "note": "\u003cskillId:61\u003e\n\u003coffhandSkillId:64\u003e\n\u003cmaxRefineCount:12\u003e\n\u003cmaxRefinedTraits:5\u003e\n\u003cthisHit:50\u003e\n\u003cthisCri:40\u003e\n\u003cthisTrg:3\u003e",
+    "description": "If two magnums had a baby, it'd be this.\nBecause it blows you into chunks with a single shot.",
+    "iconIndex": 2516,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      60,
+      0,
+      0,
+      0,
+      0,
+      60
+    ],
+    "price": 250000,
+    "animationId": 125,
+    "wtypeId": 7
+  },
+  {
+    "id": 65,
+    "name": "Zeliska",
+    "note": "\u003cskillId:61\u003e\n\u003coffhandSkillId:64\u003e\n\u003cmaxRefineCount:18\u003e\n\u003cmaxRefinedTraits:7\u003e\n\u003cthisHit:80\u003e\n\u003cthisCri:50\u003e\n\u003cthisTrg:4\u003e",
+    "description": "Six kilograms of revolver, chambered for a round meant to stop an elephant.\nAiming it is optional. Surviving it is not.",
+    "iconIndex": 2516,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      90,
+      0,
+      0,
+      0,
+      0,
+      90
+    ],
+    "price": 500000,
+    "animationId": 125,
+    "wtypeId": 7
+  },
+  {
+    "id": 66,
+    "name": "KS Model 1337",
+    "note": "\u003cskillId:61\u003e\n\u003coffhandSkillId:64\u003e\n\u003cmaxRefineCount:25\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:110\u003e\n\u003cthisCri:70\u003e\n\u003cthisTrg:5\u003e",
+    "description": "Thanks to advancements in technology,\nyour gun now looks as cool as it is lethal.",
+    "iconIndex": 1553,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      130,
+      0,
+      0,
+      0,
+      0,
+      130
+    ],
+    "price": 999999,
+    "animationId": 125,
+    "wtypeId": 7
+  },
+  {
+    "id": 67,
+    "name": "\"Burning Bullet\"",
+    "note": "\u003cskillId:61\u003e\n\u003coffhandSkillId:64\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:40\u003e\n\u003cthisCri:40\u003e\n\u003cthisTrg:3\u003e",
+    "description": "⭐ A pistol that fires angry bullets to slay its foes.\nImbued with \"Heat\", has high crit.",
+    "iconIndex": 78,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 4,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      20,
+      0,
+      0,
+      0,
+      0,
+      20
+    ],
+    "price": 0,
+    "animationId": 125,
+    "wtypeId": 7
+  },
+  {
+    "id": 68,
+    "name": "\"Hellfire Shot\"",
+    "note": "\u003cskillId:61\u003e\n\u003coffhandSkillId:64\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:70\u003e\n\u003cthisCri:100\u003e\n\u003cthisTrg:4\u003e",
+    "description": "⭐⭐ A raging pistol powered by your hatred.\nImbued with \"Heat\", has high crit.",
+    "iconIndex": 1505,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 4,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      70,
+      0,
+      0,
+      0,
+      0,
+      70
+    ],
+    "price": 0,
+    "animationId": 125,
+    "wtypeId": 7
+  },
+  {
+    "id": 69,
+    "name": "\"Xiuhcoatl\"",
+    "note": "\u003cskillId:61\u003e\n\u003coffhandSkillId:64\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:100\u003e\n\u003cthisCri:200\u003e\n\u003cthisTrg:5\u003e",
+    "description": "⭐⭐⭐ An ascended pistol that basically breathes flame bullets on your behalf.\nImbued with \"Heat\", has high crit.",
+    "iconIndex": 867,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 4,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      200,
+      0,
+      0,
+      0,
+      0,
+      200
+    ],
+    "price": 0,
+    "animationId": 125,
+    "wtypeId": 7
+  },
+  {
+    "id": 70,
+    "name": "\"Verdict\"",
+    "note": "\u003cskillId:61\u003e\n\u003coffhandSkillId:64\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:200\u003e\n\u003cthisCri:300\u003e\n\u003cthisTrg:6\u003e",
+    "description": "Everything that came before it was argument.\nThis is only the part where it is settled.",
+    "iconIndex": 867,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      260,
+      0,
+      0,
+      0,
+      0,
+      260
+    ],
+    "price": 0,
+    "animationId": 125,
+    "wtypeId": 7
+  },
+  {
+    "id": 71,
+    "name": "10-Volt Stun Gun",
+    "note": "\u003cskillId:71\u003e\n\u003coffhandSkillId:74\u003e\n\u003cmaxRefineCount:2\u003e\n\u003cmaxRefinedTraits:2\u003e\n\u003cthisHit:50\u003e\n\u003cthisCri:1\u003e\n\u003cthisTrg:5\u003e",
+    "description": "A stun gun with a weak battery.\nIt is effectively a training weapon at this point.",
+    "iconIndex": 1523,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      15,
+      0,
+      0,
+      5
+    ],
+    "price": 1000,
+    "animationId": 5,
+    "wtypeId": 8
+  },
+  {
+    "id": 72,
+    "name": "Butthole Tingler",
+    "note": "\u003cskillId:71\u003e\n\u003coffhandSkillId:74\u003e\n\u003cmaxRefineCount:5\u003e\n\u003cmaxRefinedTraits:3\u003e\n\u003cthisHit:70\u003e\n\u003cthisCri:1\u003e\n\u003cthisTrg:5\u003e",
+    "description": "After replacing the battery, the stun gun is now a STUN GUN.",
+    "iconIndex": 1523,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      30,
+      0,
+      0,
+      10
+    ],
+    "price": 10000,
+    "animationId": 5,
+    "wtypeId": 8
+  },
+  {
+    "id": 73,
+    "name": "10000-Volt Stun Gun",
+    "note": "\u003cskillId:71\u003e\n\u003coffhandSkillId:74\u003e\n\u003cmaxRefineCount:8\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:110\u003e\n\u003cthisCri:2\u003e\n\u003cthisTrg:5\u003e",
+    "description": "An extremely well-advertised and obviously good brand of battery powers this stun gun.",
+    "iconIndex": 1523,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      90,
+      0,
+      0,
+      25
+    ],
+    "price": 50000,
+    "animationId": 5,
+    "wtypeId": 8
+  },
+  {
+    "id": 74,
+    "name": "Teravolt Stun Gun",
+    "note": "\u003cskillId:71\u003e\n\u003coffhandSkillId:74\u003e\n\u003cmaxRefineCount:12\u003e\n\u003cmaxRefinedTraits:5\u003e\n\u003cthisHit:190\u003e\n\u003cthisCri:2\u003e\n\u003cthisTrg:5\u003e",
+    "description": "Packing a massive battery, you can release untold torrents of destruction on your foes.",
+    "iconIndex": 1523,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      195,
+      0,
+      0,
+      80
+    ],
+    "price": 500000,
+    "animationId": 5,
+    "wtypeId": 8
+  },
+  {
+    "id": 75,
+    "name": "Petavolt Stun Gun",
+    "note": "\u003cskillId:71\u003e\n\u003coffhandSkillId:74\u003e\n\u003cmaxRefineCount:18\u003e\n\u003cmaxRefinedTraits:7\u003e\n\u003cthisHit:260\u003e\n\u003cthisCri:2\u003e\n\u003cthisTrg:5\u003e",
+    "description": "The battery is not sold in stores, and the man who sold it to you seemed nervous about it.",
+    "iconIndex": 1523,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      290,
+      0,
+      0,
+      140
+    ],
+    "price": 750000,
+    "animationId": 5,
+    "wtypeId": 8
+  },
+  {
+    "id": 76,
+    "name": "Exavolt Stun Gun",
+    "note": "\u003cskillId:71\u003e\n\u003coffhandSkillId:74\u003e\n\u003cmaxRefineCount:25\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:340\u003e\n\u003cthisCri:2\u003e\n\u003cthisTrg:5\u003e",
+    "description": "Whatever is in the battery compartment is not, strictly speaking, a battery anymore.",
+    "iconIndex": 1523,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      400,
+      0,
+      0,
+      210
+    ],
+    "price": 999999,
+    "animationId": 5,
+    "wtypeId": 8
+  },
+  {
+    "id": 77,
+    "name": "\"Fly Zapper\"",
+    "note": "\u003cskillId:71\u003e\n\u003coffhandSkillId:74\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:90\u003e\n\u003cthisCri:1\u003e\n\u003cthisTrg:10\u003e",
+    "description": "⭐ A bugzapper that had some DIY work to make it projectile-worthy.\nDestroys insects.",
+    "iconIndex": 1535,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 17,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      50,
+      0,
+      0,
+      20
+    ],
+    "price": 0,
+    "animationId": 5,
+    "wtypeId": 8
+  },
+  {
+    "id": 78,
+    "name": "\"Defoliant\"",
+    "note": "\u003cskillId:71\u003e\n\u003coffhandSkillId:74\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:160\u003e\n\u003cthisCri:2\u003e\n\u003cthisTrg:5\u003e",
+    "description": "⭐⭐ If you continue to overcharge a bugzapper, it'll start destroying foliage, too.\nDestroys insects and plants.",
+    "iconIndex": 1535,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 17,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 15,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      200,
+      0,
+      0,
+      100
+    ],
+    "price": 0,
+    "animationId": 5,
+    "wtypeId": 8
+  },
+  {
+    "id": 79,
+    "name": "\"Teen Baan\"",
+    "note": "\u003cskillId:71\u003e\n\u003coffhandSkillId:74\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:250\u003e\n\u003cthisCri:2\u003e\n\u003cthisTrg:5\u003e",
+    "description": "⭐⭐⭐ A stun gun with an ascended battery, capable of obliterating all of humanity.\nDestroys insects, plants, and humanoids.",
+    "iconIndex": 1535,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 17,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 15,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 18,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      500,
+      0,
+      0,
+      300
+    ],
+    "price": 0,
+    "animationId": 5,
+    "wtypeId": 8
+  },
+  {
+    "id": 80,
+    "name": "\"Vitrification\"",
+    "note": "\u003cskillId:71\u003e\n\u003coffhandSkillId:74\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:450\u003e\n\u003cthisCri:2\u003e\n\u003cthisTrg:5\u003e",
+    "description": "Nothing scatters and nothing burns. There is only a smooth place where something used to be.",
+    "iconIndex": 1535,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 13,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      800,
+      0,
+      0,
+      400
+    ],
+    "price": 0,
+    "animationId": 5,
+    "wtypeId": 8
+  },
+  {
+    "id": 81,
+    "name": "Scattershot",
+    "note": "\u003cskillId:81\u003e\n\u003coffhandSkillId:83\u003e\n\u003cspeedBoost:-10\u003e\n\u003cmaxRefineCount:4\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:5\u003e\n\u003cthisCri:4\u003e\n\u003cthisTrg:1\u003e\n\u003cthisRec:30\u003e",
+    "description": "Your standard in shotguns. A bit heavy and rusty, but requires less effort.\nWielded in both hands.",
+    "iconIndex": 436,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      20,
+      0,
+      0,
+      0,
+      0,
+      5
+    ],
+    "price": 1000,
+    "animationId": 125,
+    "wtypeId": 9
+  },
+  {
+    "id": 82,
+    "name": "Tribarrel",
+    "note": "\u003cskillId:81\u003e\n\u003coffhandSkillId:83\u003e\n\u003cspeedBoost:-10\u003e\n\u003cmaxRefineCount:10\u003e\n\u003cmaxRefinedTraits:6\u003e\n\u003cthisHit:20\u003e\n\u003cthisCri:6\u003e\n\u003cthisTrg:1\u003e\n\u003cthisRec:75\u003e",
+    "description": "A triple-barrel shotgun for firing three times at once.\nWielded in both hands.",
+    "iconIndex": 436,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      50,
+      0,
+      0,
+      0,
+      0,
+      15
+    ],
+    "price": 10000,
+    "animationId": 125,
+    "wtypeId": 9
+  },
+  {
+    "id": 83,
+    "name": "Decabarrel",
+    "note": "\u003cskillId:81\u003e\n\u003coffhandSkillId:83\u003e\n\u003cspeedBoost:-10\u003e\n\u003cmaxRefineCount:16\u003e\n\u003cmaxRefinedTraits:8\u003e\n\u003cthisHit:40\u003e\n\u003cthisCri:8\u003e\n\u003cthisTrg:2\u003e\n\u003cthisRec:110\u003e",
+    "description": "A 10-barrel shotgun for firing ten times at once.\nWielded in both hands.",
+    "iconIndex": 436,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      95,
+      0,
+      0,
+      0,
+      0,
+      30
+    ],
+    "price": 50000,
+    "animationId": 125,
+    "wtypeId": 9
+  },
+  {
+    "id": 84,
+    "name": "Centibarrel",
+    "note": "\u003cskillId:81\u003e\n\u003coffhandSkillId:83\u003e\n\u003cspeedBoost:-10\u003e\n\u003cmaxRefineCount:24\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:60\u003e\n\u003cthisCri:10\u003e\n\u003cthisTrg:2\u003e\n\u003cthisRec:160\u003e",
+    "description": "A 100-barrel shotgun for firing ...not 100 times at once, but it does hit a lot!\nWielded in both hands.",
+    "iconIndex": 436,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      210,
+      0,
+      0,
+      0,
+      0,
+      70
+    ],
+    "price": 500000,
+    "animationId": 125,
+    "wtypeId": 9
+  },
+  {
+    "id": 85,
+    "name": "Kilobarrel",
+    "note": "\u003cskillId:81\u003e\n\u003coffhandSkillId:83\u003e\n\u003cspeedBoost:-10\u003e\n\u003cmaxRefineCount:36\u003e\n\u003cmaxRefinedTraits:14\u003e\n\u003cthisHit:85\u003e\n\u003cthisCri:12\u003e\n\u003cthisTrg:3\u003e\n\u003cthisRec:210\u003e",
+    "description": "A 1000-barrel shotgun. Nobody has counted them, and nobody is going to.\nWielded in both hands.",
+    "iconIndex": 436,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      340,
+      0,
+      0,
+      0,
+      0,
+      110
+    ],
+    "price": 750000,
+    "animationId": 125,
+    "wtypeId": 9
+  },
+  {
+    "id": 86,
+    "name": "Megabarrel",
+    "note": "\u003cskillId:81\u003e\n\u003coffhandSkillId:83\u003e\n\u003cspeedBoost:-10\u003e\n\u003cmaxRefineCount:50\u003e\n\u003cmaxRefinedTraits:20\u003e\n\u003cthisHit:110\u003e\n\u003cthisCri:15\u003e\n\u003cthisTrg:3\u003e\n\u003cthisRec:260\u003e",
+    "description": "A million barrels, allegedly. The paperwork burned up along with everything else.\nWielded in both hands.",
+    "iconIndex": 436,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      480,
+      0,
+      0,
+      0,
+      0,
+      160
+    ],
+    "price": 999999,
+    "animationId": 125,
+    "wtypeId": 9
+  },
+  {
+    "id": 87,
+    "name": "\"Blaster\"",
+    "note": "\u003cskillId:81\u003e\n\u003coffhandSkillId:83\u003e\n\u003cspeedBoost:-10\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:10\u003e\n\u003cthisCri:10\u003e\n\u003cthisTrg:4\u003e\n\u003cthisRec:50\u003e",
+    "description": "⭐ A unique-shaped gun for blasting holes through bitches.\nDestroys undead.",
+    "iconIndex": 1457,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 11,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      75,
+      0,
+      0,
+      0,
+      0,
+      25
+    ],
+    "price": 0,
+    "animationId": 125,
+    "wtypeId": 9
+  },
+  {
+    "id": 88,
+    "name": "\"Spray of Death\"",
+    "note": "\u003cskillId:81\u003e\n\u003coffhandSkillId:83\u003e\n\u003cspeedBoost:-10\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:65\u003e\n\u003cthisCri:15\u003e\n\u003cthisTrg:5\u003e\n\u003cthisRec:135\u003e",
+    "description": "⭐⭐ A ruthless shotgun for dealing with your average zombie apocalypse.\nDestroys undead.",
+    "iconIndex": 1457,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 11,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      300,
+      0,
+      0,
+      0,
+      0,
+      100
+    ],
+    "price": 0,
+    "animationId": 125,
+    "wtypeId": 9
+  },
+  {
+    "id": 89,
+    "name": "\"Astra\"",
+    "note": "\u003cskillId:81\u003e\n\u003coffhandSkillId:83\u003e\n\u003cspeedBoost:-10\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:75\u003e\n\u003cthisCri:20\u003e\n\u003cthisTrg:6\u003e\n\u003cthisRec:200\u003e",
+    "description": "⭐⭐⭐ A shotgun with ascended barrels for obliterating even beezlebub in one shot.\nBanishes undead.",
+    "iconIndex": 1457,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 11,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      500,
+      0,
+      0,
+      0,
+      0,
+      200
+    ],
+    "price": 0,
+    "animationId": 125,
+    "wtypeId": 9
+  },
+  {
+    "id": 90,
+    "name": "\"Legion\"",
+    "note": "\u003cskillId:81\u003e\n\u003coffhandSkillId:83\u003e\n\u003cspeedBoost:-10\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:150\u003e\n\u003cthisCri:25\u003e\n\u003cthisTrg:8\u003e\n\u003cthisRec:350\u003e",
+    "description": "Ask it what it is called, and every barrel answers.\nWielded in both hands.",
+    "iconIndex": 1457,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 2,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      960,
+      0,
+      0,
+      0,
+      0,
+      320
+    ],
+    "price": 0,
+    "animationId": 125,
+    "wtypeId": 9
+  },
+  {
+    "id": 91,
+    "name": "Kindling Hatchet",
+    "note": "\u003cskillId:91\u003e\n\u003coffhandSkillId:94\u003e\n\u003cspeedBoost:-10\u003e\n\u003cmaxRefineCount:2\u003e\n\u003cmaxRefinedTraits:2\u003e\n\u003cthisHit:15\u003e\n\u003cthisCri:4\u003e",
+    "description": "An axe sized for splitting kindling and absolutely nothing else.\nIt has never met anything that fought back.",
+    "iconIndex": 99,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      50,
+      0,
+      25,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 100,
+    "animationId": 7,
+    "wtypeId": 10
+  },
+  {
+    "id": 92,
+    "name": "Wolftrap Maul",
+    "note": "\u003cskillId:91\u003e\n\u003coffhandSkillId:94\u003e\n\u003cspeedBoost:-10\u003e\n\u003cmaxRefineCount:5\u003e\n\u003cmaxRefinedTraits:3\u003e\n\u003cthisHit:25\u003e\n\u003cthisCri:6\u003e",
+    "description": "A beginner's maul designed for easing woodchopping, but laced with wolftrap sap.\nMay apply \\State[16](20%).",
+    "iconIndex": 432,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 16,
+        "value": 0.2
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      80,
+      0,
+      45,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 1000,
+    "animationId": 7,
+    "wtypeId": 10
+  },
+  {
+    "id": 93,
+    "name": "Beartrap Hewer",
+    "note": "\u003cskillId:91\u003e\n\u003coffhandSkillId:94\u003e\n\u003cspeedBoost:-15\u003e\n\u003cmaxRefineCount:8\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:35\u003e\n\u003cthisCri:10\u003e",
+    "description": "A hewing axe glazed with resin bled from a beartrap.\nMay apply \\State[16](40%).",
+    "iconIndex": 1728,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 16,
+        "value": 0.4
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      115,
+      0,
+      70,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 5000,
+    "animationId": 7,
+    "wtypeId": 10
+  },
+  {
+    "id": 94,
+    "name": "Orctrap Cleaver",
+    "note": "\u003cskillId:91\u003e\n\u003coffhandSkillId:94\u003e\n\u003cspeedBoost:-15\u003e\n\u003cmaxRefineCount:12\u003e\n\u003cmaxRefinedTraits:5\u003e\n\u003cthisHit:50\u003e\n\u003cthisCri:15\u003e",
+    "description": "A heavy cleaver capable of doing some serious damage, laced with orctrap venom.\nMay apply \\State[16](60%).",
+    "iconIndex": 1728,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 16,
+        "value": 0.6
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      160,
+      0,
+      100,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 25000,
+    "animationId": 7,
+    "wtypeId": 10
+  },
+  {
+    "id": 95,
+    "name": "Wyrmtrap Maul",
+    "note": "\u003cskillId:91\u003e\n\u003coffhandSkillId:94\u003e\n\u003cspeedBoost:-15\u003e\n\u003cmaxRefineCount:18\u003e\n\u003cmaxRefinedTraits:7\u003e\n\u003cthisHit:75\u003e\n\u003cthisCri:25\u003e",
+    "description": "A wicked axe with a tremendous heft to it, laced with the bile of a wyrmtrap.\nMay apply \\State[16](80%).",
+    "iconIndex": 433,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 16,
+        "value": 0.8
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      280,
+      0,
+      160,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 100000,
+    "animationId": 7,
+    "wtypeId": 10
+  },
+  {
+    "id": 96,
+    "name": "Deathtrap Broadaxe",
+    "note": "\u003cskillId:91\u003e\n\u003coffhandSkillId:94\u003e\n\u003cspeedBoost:-20\u003e\n\u003cmaxRefineCount:25\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:120\u003e\n\u003cthisCri:35\u003e",
+    "description": "An axe glazed entirely with the most lethal venom in the galaxy: the Deathtrap.\nApplies \\State[16].",
+    "iconIndex": 434,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 16,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      400,
+      0,
+      215,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 500000,
+    "animationId": 7,
+    "wtypeId": 10
+  },
+  {
+    "id": 97,
+    "name": "\"Glowing Hacker\"",
+    "note": "\u003cskillId:91\u003e\n\u003coffhandSkillId:94\u003e\n\u003cspeedBoost:-10\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:60\u003e\n\u003cthisCri:10\u003e",
+    "description": "⭐ A small glowing axe, which feels static to the touch.\nDestroys constructs.",
+    "iconIndex": 563,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      100,
+      0,
+      60,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 7,
+    "wtypeId": 10
+  },
+  {
+    "id": 98,
+    "name": "\"Sky Splitter\"",
+    "note": "\u003cskillId:91\u003e\n\u003coffhandSkillId:94\u003e\n\u003cspeedBoost:-10\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:70\u003e\n\u003cthisCri:25\u003e",
+    "description": "⭐⭐ A dangerously charged and long axe that cleaves the skies.\nDestroys constructs.",
+    "iconIndex": 515,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      200,
+      0,
+      150,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 7,
+    "wtypeId": 10
+  },
+  {
+    "id": 99,
+    "name": "\"Mjolnir\"",
+    "note": "\u003cskillId:91\u003e\n\u003coffhandSkillId:94\u003e\n\u003cspeedBoost:-15\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:150\u003e\n\u003cthisCri:40\u003e",
+    "description": "⭐⭐⭐ An ascended axe- I mean chainsaw- capable of rending all asunder.\nDestroys constructs.",
+    "iconIndex": 1604,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      600,
+      0,
+      250,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 7,
+    "wtypeId": 10
+  },
+  {
+    "id": 100,
+    "name": "\"Reckoning\"",
+    "note": "\u003cskillId:91\u003e\n\u003coffhandSkillId:94\u003e\n\u003cspeedBoost:-20\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:200\u003e\n\u003cthisCri:60\u003e",
+    "description": "Every blow you walked away from was being counted.\nNothing walks away from this one.",
+    "iconIndex": 611,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      800,
+      0,
+      430,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 7,
+    "wtypeId": 10
+  },
+  {
+    "id": 101,
+    "name": "Leaden Poleaxe",
+    "note": "\u003cskillId:101\u003e\n\u003cmaxRefineCount:4\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:50\u003e\n\u003cthisCri:2\u003e",
+    "description": "So dense it fights you on the backswing. Every hit lands late and lands anyway.\nWielded in both hands.",
+    "iconIndex": 1731,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      250,
+      0,
+      35,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 1000,
+    "animationId": 7,
+    "wtypeId": 11
+  },
+  {
+    "id": 102,
+    "name": "Bulky Sagaris",
+    "note": "\u003cskillId:101\u003e\n\u003cmaxRefineCount:10\u003e\n\u003cmaxRefinedTraits:6\u003e\n\u003cthisHit:55\u003e\n\u003cthisCri:4\u003e",
+    "description": "A Scythian pattern rendered in far too much iron. Shorter recovery, marginally.\nWielded in both hands.",
+    "iconIndex": 411,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      800,
+      0,
+      100,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 5000,
+    "animationId": 7,
+    "wtypeId": 11
+  },
+  {
+    "id": 103,
+    "name": "Balanced Battleaxe",
+    "note": "\u003cskillId:101\u003e\n\u003cmaxRefineCount:16\u003e\n\u003cmaxRefinedTraits:8\u003e\n\u003cthisHit:110\u003e\n\u003cthisCri:6\u003e",
+    "description": "The point where the axe stops arguing. Head and haft finally agree on where to go.\nWielded in both hands.",
+    "iconIndex": 499,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      1400,
+      0,
+      165,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 25000,
+    "animationId": 7,
+    "wtypeId": 11
+  },
+  {
+    "id": 104,
+    "name": "Nimble Labrys",
+    "note": "\u003cskillId:101\u003e\n\u003cmaxRefineCount:24\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:160\u003e\n\u003cthisCri:8\u003e",
+    "description": "Twin heads, and somehow lighter than the one before it. The arc closes noticeably faster.\nWielded in both hands.",
+    "iconIndex": 1730,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      2000,
+      0,
+      240,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 125000,
+    "animationId": 7,
+    "wtypeId": 11
+  },
+  {
+    "id": 105,
+    "name": "Featherweight Bardiche",
+    "note": "\u003cskillId:101\u003e\n\u003cmaxRefineCount:36\u003e\n\u003cmaxRefinedTraits:14\u003e\n\u003cthisHit:220\u003e\n\u003cthisCri:10\u003e",
+    "description": "A polearm you can hold at arm's length one-handed, if only to prove it.\nWielded in both hands.",
+    "iconIndex": 1730,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      2700,
+      0,
+      325,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 500000,
+    "animationId": 7,
+    "wtypeId": 11
+  },
+  {
+    "id": 106,
+    "name": "Gossamer Halberd",
+    "note": "\u003cskillId:101\u003e\n\u003cmaxRefineCount:50\u003e\n\u003cmaxRefinedTraits:20\u003e\n\u003cthisHit:290\u003e\n\u003cthisCri:12\u003e",
+    "description": "You can see the far wall through the blade. It comes back around before you finish swinging it.\nWielded in both hands.",
+    "iconIndex": 1730,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      3500,
+      0,
+      420,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 999999,
+    "animationId": 7,
+    "wtypeId": 11
+  },
+  {
+    "id": 107,
+    "name": "\"Crescent Blossom\"",
+    "note": "\u003cskillId:101\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:75\u003e\n\u003cthisCri:5\u003e",
+    "description": "⭐ A crescent of an axe, opening an arc barely wider than your reach.\nDestroys humanoids, wielded in both hands.",
+    "iconIndex": 1733,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 18,
+        "value": 1
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      1000,
+      0,
+      150,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 7,
+    "wtypeId": 11
+  },
+  {
+    "id": 108,
+    "name": "\"Half-Moon Bloom\"",
+    "note": "\u003cskillId:101\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:125\u003e\n\u003cthisCri:10\u003e",
+    "description": "⭐⭐ The arc widens past half a circle, and nothing inside it gets a say.\nWielded in both hands.",
+    "iconIndex": 1732,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      2500,
+      0,
+      300,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 7,
+    "wtypeId": 11
+  },
+  {
+    "id": 109,
+    "name": "\"Ecliptic Efflorescence\"",
+    "note": "\u003cskillId:101\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:225\u003e\n\u003cthisCri:15\u003e",
+    "description": "⭐⭐⭐ The swing closes on itself. Everything within the arc is simply gone.\nWielded in both hands.",
+    "iconIndex": 122,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      4500,
+      0,
+      500,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 7,
+    "wtypeId": 11
+  },
+  {
+    "id": 110,
+    "name": "\"The Styrofoam Axe\"",
+    "note": "\u003cskillId:101\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:400\u003e\n\u003cthisCri:30\u003e",
+    "description": "Weighs nothing. Has never chipped, never bent, and has never once failed\nto go all the way through. Wielded in both hands.",
+    "iconIndex": 515,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      7000,
+      0,
+      840,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 7,
+    "wtypeId": 11
+  },
+  {
+    "id": 111,
+    "name": "Khopesh",
+    "note": "\u003cskillId:111\u003e\n\u003coffhandSkillId:115\u003e\n\u003cspeedBoost:-5\u003e\n\u003cignoreParry:10\u003e\n\u003cmaxRefineCount:4\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:30\u003e\n\u003cthisCri:15\u003e",
+    "description": "A bronze sickle-sword whose hook exists to drag a shield out of the way.\nWielded in both hands.",
+    "iconIndex": 518,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      50,
+      0,
+      30,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 500,
+    "animationId": 7,
+    "wtypeId": 12
+  },
+  {
+    "id": 112,
+    "name": "Shotel",
+    "note": "\u003cskillId:111\u003e\n\u003coffhandSkillId:115\u003e\n\u003cspeedBoost:-5\u003e\n\u003cignoreParry:20\u003e\n\u003cmaxRefineCount:10\u003e\n\u003cmaxRefinedTraits:6\u003e\n\u003cthisHit:80\u003e\n\u003cthisCri:25\u003e",
+    "description": "Curved so far past sense that it reaches around a shield to the man behind it.\nWielded in both hands.",
+    "iconIndex": 518,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      100,
+      0,
+      65,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 2500,
+    "animationId": 7,
+    "wtypeId": 12
+  },
+  {
+    "id": 113,
+    "name": "Falx",
+    "note": "\u003cskillId:111\u003e\n\u003coffhandSkillId:115\u003e\n\u003cspeedBoost:-10\u003e\n\u003cignoreParry:30\u003e\n\u003cmaxRefineCount:16\u003e\n\u003cmaxRefinedTraits:8\u003e\n\u003cthisHit:110\u003e\n\u003cthisCri:35\u003e",
+    "description": "It came over the shield rim so hard that an empire redesigned its helmets.\nWielded in both hands.",
+    "iconIndex": 518,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      300,
+      0,
+      100,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 10000,
+    "animationId": 7,
+    "wtypeId": 12
+  },
+  {
+    "id": 114,
+    "name": "Rhomphaia",
+    "note": "\u003cskillId:111\u003e\n\u003coffhandSkillId:115\u003e\n\u003cspeedBoost:-10\u003e\n\u003cignoreParry:40\u003e\n\u003cmaxRefineCount:24\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:190\u003e\n\u003cthisCri:50\u003e",
+    "description": "The falx given a longer shaft, so the reach arrives well before the answer does.\nWielded in both hands.",
+    "iconIndex": 518,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      550,
+      0,
+      160,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 50000,
+    "animationId": 7,
+    "wtypeId": 12
+  },
+  {
+    "id": 115,
+    "name": "Tepoztopilli",
+    "note": "\u003cskillId:111\u003e\n\u003coffhandSkillId:115\u003e\n\u003cspeedBoost:-10\u003e\n\u003cignoreParry:50\u003e\n\u003cmaxRefineCount:36\u003e\n\u003cmaxRefinedTraits:14\u003e\n\u003cthisHit:250\u003e\n\u003cthisCri:65\u003e",
+    "description": "Rows of volcanic glass set along a shaft, every edge only a few atoms wide.\nWielded in both hands.",
+    "iconIndex": 518,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      850,
+      0,
+      230,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 200000,
+    "animationId": 7,
+    "wtypeId": 12
+  },
+  {
+    "id": 116,
+    "name": "Urumi",
+    "note": "\u003cskillId:111\u003e\n\u003coffhandSkillId:115\u003e\n\u003cspeedBoost:-15\u003e\n\u003cignoreParry:60\u003e\n\u003cmaxRefineCount:50\u003e\n\u003cmaxRefinedTraits:20\u003e\n\u003cthisHit:320\u003e\n\u003cthisCri:80\u003e",
+    "description": "Several flexible razors that do not go through a guard so much as around it.\nWielded in both hands.",
+    "iconIndex": 518,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      1200,
+      0,
+      310,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 750000,
+    "animationId": 7,
+    "wtypeId": 12
+  },
+  {
+    "id": 117,
+    "name": "\"Plate Peeler\"",
+    "note": "\u003cskillId:111\u003e\n\u003coffhandSkillId:115\u003e\n\u003cspeedBoost:-5\u003e\n\u003cignoreParry:25\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:50\u003e\n\u003cthisCri:20\u003e",
+    "description": "⭐ It gets under the edge of whatever you are wearing, and then it lifts.\nWielded in both hands.",
+    "iconIndex": 614,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      200,
+      0,
+      75,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 7,
+    "wtypeId": 12
+  },
+  {
+    "id": 118,
+    "name": "\"Bared Truth\"",
+    "note": "\u003cskillId:111\u003e\n\u003coffhandSkillId:115\u003e\n\u003cspeedBoost:-5\u003e\n\u003cignoreParry:50\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:150\u003e\n\u003cthisCri:40\u003e",
+    "description": "⭐⭐ By the third swing there is nothing at all left between you and it.\nWielded in both hands.",
+    "iconIndex": 614,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      700,
+      0,
+      200,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 7,
+    "wtypeId": 12
+  },
+  {
+    "id": 119,
+    "name": "\"Fragarach\"",
+    "note": "\u003cskillId:111\u003e\n\u003coffhandSkillId:115\u003e\n\u003cignoreParry:75\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:250\u003e\n\u003cthisCri:60\u003e",
+    "description": "⭐⭐⭐ The Answerer. It cuts any shield, any wall, and any story you told about either.\nWielded in both hands.",
+    "iconIndex": 614,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      1500,
+      0,
+      500,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 7,
+    "wtypeId": 12
+  },
+  {
+    "id": 120,
+    "name": "\"Ablation\"",
+    "note": "\u003cskillId:111\u003e\n\u003coffhandSkillId:115\u003e\n\u003cunparryable\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:450\u003e\n\u003cthisCri:120\u003e",
+    "description": "Nothing here is defeated. It is removed, one layer at a time, until there is no next layer.\nWielded in both hands.",
+    "iconIndex": 614,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      2400,
+      0,
+      620,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 7,
+    "wtypeId": 12
+  },
+  {
+    "id": 121,
+    "name": "Plain Crook",
+    "note": "\u003cskillId:121\u003e\n\u003coffhandSkillId:124\u003e\n\u003cmaxRefineCount:4\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:10\u003e\n\u003cthisMrg:3\u003e",
+    "description": "A stick. There is nothing on it. Someone has assured you it is slightly magical.\nWielded in both hands.",
+    "iconIndex": 388,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      20,
+      10,
+      0,
+      0
+    ],
+    "price": 100,
+    "animationId": 2,
+    "wtypeId": 13
+  },
+  {
+    "id": 122,
+    "name": "Oak Staff",
+    "note": "\u003cskillId:121\u003e\n\u003coffhandSkillId:124\u003e\n\u003cmaxRefineCount:10\u003e\n\u003cmaxRefinedTraits:6\u003e\n\u003cthisHit:25\u003e\n\u003cthisMrg:6\u003e",
+    "description": "A well-made oaken staff, a proper accompaniment to any aspiring mage.\nWielded in both hands.",
+    "iconIndex": 101,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      55,
+      20,
+      0,
+      0
+    ],
+    "price": 1000,
+    "animationId": 2,
+    "wtypeId": 13
+  },
+  {
+    "id": 123,
+    "name": "Mage Staff",
+    "note": "\u003cskillId:121\u003e\n\u003coffhandSkillId:124\u003e\n\u003cmaxRefineCount:16\u003e\n\u003cmaxRefinedTraits:8\u003e\n\u003cthisHit:50\u003e\n\u003cthisMrg:8\u003e",
+    "description": "An oaken staff adorned with dreamcatcher-like mesh.\nWielded in both hands.",
+    "iconIndex": 1749,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      75,
+      25,
+      0,
+      0
+    ],
+    "price": 5000,
+    "animationId": 2,
+    "wtypeId": 13
+  },
+  {
+    "id": 124,
+    "name": "Bangled Staff",
+    "note": "\u003cskillId:121\u003e\n\u003coffhandSkillId:124\u003e\n\u003cmaxRefineCount:24\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:60\u003e\n\u003cthisMrg:15\u003e",
+    "description": "Hung with rings, charms and small bells. It announces you from some distance.\nWielded in both hands.",
+    "iconIndex": 1741,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      120,
+      40,
+      0,
+      0
+    ],
+    "price": 25000,
+    "animationId": 2,
+    "wtypeId": 13
+  },
+  {
+    "id": 125,
+    "name": "Bedazzled Staff",
+    "note": "\u003cskillId:121\u003e\n\u003coffhandSkillId:124\u003e\n\u003cmaxRefineCount:36\u003e\n\u003cmaxRefinedTraits:14\u003e\n\u003cthisHit:80\u003e\n\u003cthisMrg:18\u003e",
+    "description": "An ancient relic of the shaman's of past. The kawaii ones, obviously.\nWielded in both hands.",
+    "iconIndex": 1750,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      175,
+      60,
+      0,
+      0
+    ],
+    "price": 100000,
+    "animationId": 2,
+    "wtypeId": 13
+  },
+  {
+    "id": 126,
+    "name": "Overwrought Staff",
+    "note": "\u003cskillId:121\u003e\n\u003coffhandSkillId:124\u003e\n\u003cmaxRefineCount:50\u003e\n\u003cmaxRefinedTraits:20\u003e\n\u003cthisHit:100\u003e\n\u003cthisMrg:24\u003e",
+    "description": "Somewhere underneath all of that there is a stick, and it is doing its best.\nWielded in both hands.",
+    "iconIndex": 1750,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      240,
+      85,
+      0,
+      0
+    ],
+    "price": 500000,
+    "animationId": 2,
+    "wtypeId": 13
+  },
+  {
+    "id": 127,
+    "name": "\"Still Water\"",
+    "note": "\u003cskillId:121\u003e\n\u003coffhandSkillId:124\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:50\u003e\n\u003cthisMrg:10\u003e",
+    "description": "⭐ Placid, level, and considerably deeper than it looks.\nImbued with \"Liquid\", may apply \\State[10](25%), wielded in both hands.",
+    "iconIndex": 1639,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 5,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 10,
+        "value": 0.25
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      70,
+      23,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 3,
+    "wtypeId": 13
+  },
+  {
+    "id": 128,
+    "name": "\"Quiet Drowning\"",
+    "note": "\u003cskillId:121\u003e\n\u003coffhandSkillId:124\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:70\u003e\n\u003cthisMrg:20\u003e",
+    "description": "⭐⭐ There is no thrashing. That part is already finished.\nImbued with \"Liquid\", may apply \\State[10](50%), wielded in both hands.",
+    "iconIndex": 1746,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 5,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 10,
+        "value": 0.5
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      150,
+      50,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 3,
+    "wtypeId": 13
+  },
+  {
+    "id": 129,
+    "name": "\"Ruyi\"",
+    "note": "\u003cskillId:121\u003e\n\u003coffhandSkillId:124\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:120\u003e\n\u003cthisMrg:30\u003e",
+    "description": "⭐⭐⭐ The pillar that measured the depth of the seas, and then settled them.\nImbued with \"Liquid\", applies \\State[10], wielded in both hands.",
+    "iconIndex": 532,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 5,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 10,
+        "value": 1
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      250,
+      100,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 3,
+    "wtypeId": 13
+  },
+  {
+    "id": 130,
+    "name": "\"Opalescence\"",
+    "note": "\u003cskillId:121\u003e\n\u003coffhandSkillId:124\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:200\u003e\n\u003cthisMrg:50\u003e",
+    "description": "Every colour there is, held in water that must never be allowed to leave.\nApplies \\State[10]. Wielded in both hands.",
+    "iconIndex": 532,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 5,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 10,
+        "value": 1
+      },
+      {
+        "code": 54,
+        "dataId": 2,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      500,
+      180,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 3,
+    "wtypeId": 13
+  },
+  {
+    "id": 131,
+    "name": "Taper Wand",
+    "note": "\u003cskillId:131\u003e\n\u003coffhandSkillId:134\u003e\n\u003cspeedBoost:15\u003e\n\u003cmaxRefineCount:2\u003e\n\u003cmaxRefinedTraits:2\u003e\n\u003cthisHit:40\u003e\n\u003cthisMrg:1\u003e",
+    "description": "Narrows to a point, and concentrates almost nothing on the way through.\nDeconstructs slimes.",
+    "iconIndex": 1751,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 14,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      50,
+      0,
+      0,
+      0
+    ],
+    "price": 1000,
+    "animationId": 1,
+    "wtypeId": 14
+  },
+  {
+    "id": 132,
+    "name": "Condenser Rod",
+    "note": "\u003cskillId:131\u003e\n\u003coffhandSkillId:134\u003e\n\u003cspeedBoost:15\u003e\n\u003cmaxRefineCount:5\u003e\n\u003cmaxRefinedTraits:3\u003e\n\u003cthisHit:55\u003e\n\u003cthisMrg:2\u003e",
+    "description": "Gathers what you put into it, and gives most of it back at once.\nDeconstructs slimes.",
+    "iconIndex": 614,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 14,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      80,
+      0,
+      0,
+      0
+    ],
+    "price": 5000,
+    "animationId": 1,
+    "wtypeId": 14
+  },
+  {
+    "id": 133,
+    "name": "Convergence Rod",
+    "note": "\u003cskillId:131\u003e\n\u003coffhandSkillId:134\u003e\n\u003cspeedBoost:15\u003e\n\u003cmaxRefineCount:8\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:100\u003e\n\u003cthisMrg:3\u003e",
+    "description": "Every line you draw arrives at the same place, whether it meant to or not.\nDeconstructs slimes.",
+    "iconIndex": 441,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 14,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      205,
+      0,
+      0,
+      0
+    ],
+    "price": 25000,
+    "animationId": 1,
+    "wtypeId": 14
+  },
+  {
+    "id": 134,
+    "name": "Crescendo Rod",
+    "note": "\u003cskillId:131\u003e\n\u003coffhandSkillId:134\u003e\n\u003cspeedBoost:15\u003e\n\u003cmaxRefineCount:12\u003e\n\u003cmaxRefinedTraits:5\u003e\n\u003cthisHit:140\u003e\n\u003cthisMrg:5\u003e",
+    "description": "The build is audible now. Bystanders have begun stepping backwards.\nDeconstructs slimes.",
+    "iconIndex": 442,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 14,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      280,
+      0,
+      0,
+      0
+    ],
+    "price": 100000,
+    "animationId": 1,
+    "wtypeId": 14
+  },
+  {
+    "id": 135,
+    "name": "Culmination Rod",
+    "note": "\u003cskillId:131\u003e\n\u003coffhandSkillId:134\u003e\n\u003cspeedBoost:15\u003e\n\u003cmaxRefineCount:18\u003e\n\u003cmaxRefinedTraits:7\u003e\n\u003cthisHit:190\u003e\n\u003cthisMrg:8\u003e",
+    "description": "Everything that was ever going to gather has finished gathering.\nDeconstructs slimes.",
+    "iconIndex": 442,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 14,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      390,
+      0,
+      0,
+      0
+    ],
+    "price": 400000,
+    "animationId": 1,
+    "wtypeId": 14
+  },
+  {
+    "id": 136,
+    "name": "Critical Mass",
+    "note": "\u003cskillId:131\u003e\n\u003coffhandSkillId:134\u003e\n\u003cspeedBoost:15\u003e\n\u003cmaxRefineCount:25\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:250\u003e\n\u003cthisMrg:12\u003e",
+    "description": "Past this point it proceeds with or without your further involvement.\nDeconstructs slimes.",
+    "iconIndex": 442,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 14,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      520,
+      0,
+      0,
+      0
+    ],
+    "price": 999999,
+    "animationId": 1,
+    "wtypeId": 14
+  },
+  {
+    "id": 137,
+    "name": "\"First Light\"",
+    "note": "\u003cskillId:131\u003e\n\u003coffhandSkillId:134\u003e\n\u003cspeedBoost:15\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:80\u003e\n\u003cthisMrg:5\u003e",
+    "description": "⭐ The moment before anyone has decided what sort of day this will be.\nImbued with \"Energy\", may apply \\State[13](25%), deconstructs slimes.",
+    "iconIndex": 864,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 14,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 8,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 13,
+        "value": 0.25
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      115,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 4,
+    "wtypeId": 14
+  },
+  {
+    "id": 138,
+    "name": "\"Zenith\"",
+    "note": "\u003cskillId:131\u003e\n\u003coffhandSkillId:134\u003e\n\u003cspeedBoost:15\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:120\u003e\n\u003cthisMrg:8\u003e",
+    "description": "⭐⭐ Directly overhead, casting no shadow at all, and impossible to look at.\nImbued with \"Energy\", may apply \\State[13](50%), deconstructs slimes.",
+    "iconIndex": 727,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 14,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 8,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 13,
+        "value": 0.5
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      300,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 4,
+    "wtypeId": 14
+  },
+  {
+    "id": 139,
+    "name": "\"Vajra\"",
+    "note": "\u003cskillId:131\u003e\n\u003coffhandSkillId:134\u003e\n\u003cspeedBoost:15\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:200\u003e\n\u003cthisMrg:10\u003e",
+    "description": "⭐⭐⭐ Thunderbolt and diamond at once- irresistible, and perfectly clear.\nImbued with \"Energy\", applies \\State[13], deconstructs slimes.",
+    "iconIndex": 596,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 14,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 8,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 13,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      700,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 4,
+    "wtypeId": 14
+  },
+  {
+    "id": 140,
+    "name": "\"Apotheosis\"",
+    "note": "\u003cskillId:131\u003e\n\u003coffhandSkillId:134\u003e\n\u003cspeedBoost:15\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:400\u003e\n\u003cthisMrg:25\u003e",
+    "description": "Everything you gathered, arriving all at once, as light.\nIt remains, technically, a punch. Applies \\State[13], deconstructs slimes.",
+    "iconIndex": 612,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 14,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 8,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 13,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      0,
+      0,
+      990,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 4,
+    "wtypeId": 14
+  },
+  {
+    "id": 141,
+    "name": "Pamphlet",
+    "note": "\u003cskillId:141\u003e\n\u003coffhandSkillId:143\u003e\n\u003cmaxRefineCount:2\u003e\n\u003cmaxRefinedTraits:2\u003e\n\u003cthisHit:5\u003e\n\u003cthisMrg:2\u003e",
+    "description": "Someone pressed this into your hand on a street corner.\nYou have not been able to put it down since.",
+    "iconIndex": 1539,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      250,
+      0,
+      0,
+      35,
+      19,
+      0,
+      0
+    ],
+    "price": 1000,
+    "animationId": 1,
+    "wtypeId": 15
+  },
+  {
+    "id": 142,
+    "name": "Errata",
+    "note": "\u003cskillId:141\u003e\n\u003coffhandSkillId:143\u003e\n\u003cmaxRefineCount:5\u003e\n\u003cmaxRefinedTraits:3\u003e\n\u003cthisHit:15\u003e\n\u003cthisMrg:5\u003e",
+    "description": "A list of every mistake in a book you were not reading.\nIt is longer than the book.",
+    "iconIndex": 2062,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      400,
+      0,
+      0,
+      90,
+      55,
+      0,
+      0
+    ],
+    "price": 5000,
+    "animationId": 1,
+    "wtypeId": 15
+  },
+  {
+    "id": 143,
+    "name": "Treatise",
+    "note": "\u003cskillId:141\u003e\n\u003coffhandSkillId:143\u003e\n\u003cmaxRefineCount:8\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:60\u003e\n\u003cthisMrg:7\u003e",
+    "description": "Four hundred pages arguing a point that nobody had disputed.\nThe footnotes have footnotes.",
+    "iconIndex": 1548,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      950,
+      0,
+      0,
+      220,
+      150,
+      0,
+      0
+    ],
+    "price": 25000,
+    "animationId": 1,
+    "wtypeId": 15
+  },
+  {
+    "id": 144,
+    "name": "Compendium",
+    "note": "\u003cskillId:141\u003e\n\u003coffhandSkillId:143\u003e\n\u003cmaxRefineCount:12\u003e\n\u003cmaxRefinedTraits:5\u003e\n\u003cthisHit:70\u003e\n\u003cthisMrg:10\u003e",
+    "description": "Everything known on the subject, gathered by somebody who could not stop.\nThere is no index.",
+    "iconIndex": 2063,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      1200,
+      0,
+      0,
+      265,
+      210,
+      0,
+      0
+    ],
+    "price": 100000,
+    "animationId": 1,
+    "wtypeId": 15
+  },
+  {
+    "id": 145,
+    "name": "Surreal Opus",
+    "note": "\u003cskillId:141\u003e\n\u003coffhandSkillId:143\u003e\n\u003cmaxRefineCount:18\u003e\n\u003cmaxRefinedTraits:7\u003e\n\u003cthisHit:85\u003e\n\u003cthisMrg:14\u003e",
+    "description": "The final works of one of the grandest archmages to ever live, \\_ever\\_.\nNobody has ever finished it.",
+    "iconIndex": 2063,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      1600,
+      0,
+      0,
+      355,
+      285,
+      0,
+      0
+    ],
+    "price": 400000,
+    "animationId": 1,
+    "wtypeId": 15
+  },
+  {
+    "id": 146,
+    "name": "Unabridged",
+    "note": "\u003cskillId:141\u003e\n\u003coffhandSkillId:143\u003e\n\u003cmaxRefineCount:25\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:100\u003e\n\u003cthisMrg:18\u003e",
+    "description": "Every word, every volume, no cuts, and the appendices are in another language.\nYou will be here a while. So will they.",
+    "iconIndex": 2063,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      2100,
+      0,
+      0,
+      465,
+      375,
+      0,
+      0
+    ],
+    "price": 999999,
+    "animationId": 1,
+    "wtypeId": 15
+  },
+  {
+    "id": 147,
+    "name": "\"Chained Volume\"",
+    "note": "\u003cskillId:141\u003e\n\u003coffhandSkillId:143\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:65\u003e\n\u003cthisMrg:8\u003e",
+    "description": "⭐ Somebody decided this one needed restraining, and they were correct.\nImbued with \"Void\", may apply \\State[14](25%).",
+    "iconIndex": 2059,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 9,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 14,
+        "value": 0.25
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      500,
+      0,
+      0,
+      150,
+      75,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 101,
+    "wtypeId": 15
+  },
+  {
+    "id": 148,
+    "name": "\"Apocrypha\"",
+    "note": "\u003cskillId:141\u003e\n\u003coffhandSkillId:143\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:65\u003e\n\u003cthisMrg:15\u003e",
+    "description": "⭐⭐ Kept out of the canon by people who had read it first and then voted.\nImbued with \"Void\", may apply \\State[14](50%).",
+    "iconIndex": 2060,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 9,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 14,
+        "value": 0.5
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      1500,
+      0,
+      0,
+      300,
+      225,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 101,
+    "wtypeId": 15
+  },
+  {
+    "id": 149,
+    "name": "\"Rauðskinna\"",
+    "note": "\u003cskillId:141\u003e\n\u003coffhandSkillId:143\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:100\u003e\n\u003cthisMrg:20\u003e",
+    "description": "⭐⭐⭐ Gold lettering on red vellum, buried in a grave to make quite certain of it.\nImbued with \"Void\", applies \\State[14], defeats deities.",
+    "iconIndex": 2063,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 9,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 20,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 14,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      2500,
+      0,
+      0,
+      750,
+      450,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 101,
+    "wtypeId": 15
+  },
+  {
+    "id": 150,
+    "name": "\"Anathema\"",
+    "note": "\u003cskillId:141\u003e\n\u003coffhandSkillId:143\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:200\u003e\n\u003cthisMrg:40\u003e",
+    "description": "It is not so much a book as a sentence, and it has already been handed down.\nApplies \\State[14], defeats deities.",
+    "iconIndex": 2063,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 9,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 20,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 14,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      4200,
+      0,
+      0,
+      940,
+      750,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 101,
+    "wtypeId": 15
+  },
+  {
+    "id": 151,
+    "name": "Worn Glove",
+    "note": "\u003cskillId:151\u003e\n\u003coffhandSkillId:154\u003e\n\u003cspeedBoost:10\u003e\n\u003cmaxRefineCount:2\u003e\n\u003cmaxRefinedTraits:2\u003e\n\u003cthisHit:15\u003e",
+    "description": "It has seen many an action. What that action was remains a mystery, so just wear it.\nImbued with \"Air\" and \"Ground\".",
+    "iconIndex": 392,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 6,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 7,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      20,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 100,
+    "animationId": 1,
+    "wtypeId": 16
+  },
+  {
+    "id": 152,
+    "name": "Leather Fists",
+    "note": "\u003cskillId:151\u003e\n\u003coffhandSkillId:154\u003e\n\u003cspeedBoost:10\u003e\n\u003cmaxRefineCount:5\u003e\n\u003cmaxRefinedTraits:3\u003e\n\u003cthisHit:25\u003e",
+    "description": "You only punch with one hand, so just put them both on the same hand for extra power!\nImbued with \"Air\" and \"Ground\", may apply \\State[11] and \\State[12](10%).",
+    "iconIndex": 142,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 6,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 7,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 11,
+        "value": 0.1
+      },
+      {
+        "code": 32,
+        "dataId": 12,
+        "value": 0.1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      45,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 1000,
+    "animationId": 1,
+    "wtypeId": 16
+  },
+  {
+    "id": 153,
+    "name": "Studded Hands",
+    "note": "\u003cskillId:151\u003e\n\u003coffhandSkillId:154\u003e\n\u003cspeedBoost:10\u003e\n\u003cmaxRefineCount:8\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:55\u003e",
+    "description": "Mighty hands studded with rocks and shit.\nImbued with \"Air\" and \"Ground\", may apply \\State[11] and \\State[12](20%).",
+    "iconIndex": 456,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 6,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 7,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 11,
+        "value": 0.2
+      },
+      {
+        "code": 32,
+        "dataId": 12,
+        "value": 0.2
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      80,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 5000,
+    "animationId": 1,
+    "wtypeId": 16
+  },
+  {
+    "id": 154,
+    "name": "Granite Gloves",
+    "note": "\u003cskillId:151\u003e\n\u003coffhandSkillId:154\u003e\n\u003cspeedBoost:10\u003e\n\u003cmaxRefineCount:12\u003e\n\u003cmaxRefinedTraits:5\u003e\n\u003cthisHit:90\u003e",
+    "description": "Fists made of pure granite, meaning they are unbearably heavy.\nImbued with \"Air\" and \"Ground\", may apply \\State[11] and \\State[12](30%).",
+    "iconIndex": 2588,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 6,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 7,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 11,
+        "value": 0.3
+      },
+      {
+        "code": 32,
+        "dataId": 12,
+        "value": 0.3
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      125,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 25000,
+    "animationId": 1,
+    "wtypeId": 16
+  },
+  {
+    "id": 155,
+    "name": "Terra Fists",
+    "note": "\u003cskillId:151\u003e\n\u003coffhandSkillId:154\u003e\n\u003cspeedBoost:10\u003e\n\u003cmaxRefineCount:18\u003e\n\u003cmaxRefinedTraits:7\u003e\n\u003cthisHit:125\u003e",
+    "description": "Fists that radiate ground energy, possibly related to \\N[3].\nImbued with \"Air\" and \"Ground\", may apply \\State[11] and \\State[12](40%).",
+    "iconIndex": 553,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 6,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 7,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 11,
+        "value": 0.4
+      },
+      {
+        "code": 32,
+        "dataId": 12,
+        "value": 0.4
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      185,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 100000,
+    "animationId": 1,
+    "wtypeId": 16
+  },
+  {
+    "id": 156,
+    "name": "Meteor Knuckles",
+    "note": "\u003cskillId:151\u003e\n\u003coffhandSkillId:154\u003e\n\u003cspeedBoost:10\u003e\n\u003cmaxRefineCount:25\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:170\u003e",
+    "description": "Skystone that spent a very long time falling and has not entirely finished arriving.\nImbued with \"Air\" and \"Ground\", may apply \\State[11] and \\State[12](50%).",
+    "iconIndex": 554,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 6,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 7,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 11,
+        "value": 0.5
+      },
+      {
+        "code": 32,
+        "dataId": 12,
+        "value": 0.5
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      260,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 500000,
+    "animationId": 1,
+    "wtypeId": 16
+  },
+  {
+    "id": 157,
+    "name": "\"Empty Hand\"",
+    "note": "\u003cskillId:151\u003e\n\u003coffhandSkillId:154\u003e\n\u003cspeedBoost:10\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:80\u003e",
+    "description": "⭐ Nothing in these hands at all, which turns out to be the entire argument.\nDisarms the weaponized, may apply \\State[7] and \\State[6](33%).",
+    "iconIndex": 2578,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 21,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 7,
+        "value": 0.33
+      },
+      {
+        "code": 32,
+        "dataId": 6,
+        "value": 0.33
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      60,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 1,
+    "wtypeId": 16
+  },
+  {
+    "id": 158,
+    "name": "\"Nothing Left\"",
+    "note": "\u003cskillId:151\u003e\n\u003coffhandSkillId:154\u003e\n\u003cspeedBoost:10\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:100\u003e",
+    "description": "⭐⭐ Whatever they brought with them, they are not bringing it home.\nDisarms the weaponized, may apply \\State[7] and \\State[6](66%).",
+    "iconIndex": 459,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 21,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 7,
+        "value": 0.66
+      },
+      {
+        "code": 32,
+        "dataId": 6,
+        "value": 0.66
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      180,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 1,
+    "wtypeId": 16
+  },
+  {
+    "id": 159,
+    "name": "\"Hecatoncheire\"",
+    "note": "\u003cskillId:151\u003e\n\u003coffhandSkillId:154\u003e\n\u003cspeedBoost:10\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:150\u003e",
+    "description": "⭐⭐⭐ A hundred hands, and not one of them holding a thing.\nDisarms the weaponized, applies \\State[7] and \\State[6].",
+    "iconIndex": 2585,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 21,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 7,
+        "value": 1
+      },
+      {
+        "code": 32,
+        "dataId": 6,
+        "value": 1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      300,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 1,
+    "wtypeId": 16
+  },
+  {
+    "id": 160,
+    "name": "\"Concussion\"",
+    "note": "\u003cskillId:151\u003e\n\u003coffhandSkillId:154\u003e\n\u003cspeedBoost:10\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:280\u003e",
+    "description": "No element, no edge, and no clever trick left to explain it away.\nPure force, which nothing in the world has ever learned to resist.",
+    "iconIndex": 2586,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      520,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 1,
+    "wtypeId": 16
+  },
+  {
+    "id": 161,
+    "name": "Skinning Hooks",
+    "note": "\u003cskillId:161\u003e\n\u003coffhandSkillId:164\u003e\n\u003cspeedBoost:5\u003e\n\u003cmaxRefineCount:2\u003e\n\u003cmaxRefinedTraits:2\u003e\n\u003cthisHit:50\u003e\n\u003cthisCri:6\u003e",
+    "description": "Hooks for getting a hide off something that would rather have kept it.\nSlays beasts.",
+    "iconIndex": 105,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 16,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      30,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 500,
+    "animationId": 1,
+    "wtypeId": 17
+  },
+  {
+    "id": 162,
+    "name": "Husk Splitters",
+    "note": "\u003cskillId:161\u003e\n\u003coffhandSkillId:164\u003e\n\u003cspeedBoost:5\u003e\n\u003cmaxRefineCount:5\u003e\n\u003cmaxRefinedTraits:3\u003e\n\u003cthisHit:110\u003e\n\u003cthisCri:8\u003e",
+    "description": "The shell is the easy part. What is folded up inside it takes practice.\nSlays beasts and insects.",
+    "iconIndex": 377,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 16,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 17,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      70,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 2500,
+    "animationId": 1,
+    "wtypeId": 17
+  },
+  {
+    "id": 163,
+    "name": "Underbelly Rippers",
+    "note": "\u003cskillId:161\u003e\n\u003coffhandSkillId:164\u003e\n\u003cspeedBoost:5\u003e\n\u003cmaxRefineCount:8\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:180\u003e\n\u003cthisCri:10\u003e",
+    "description": "You will never get through the scales, so it is fortunate nothing is scaled underneath.\nSlays beasts, insects, and reptiles.",
+    "iconIndex": 322,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 16,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 17,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 12,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      125,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 10000,
+    "animationId": 1,
+    "wtypeId": 17
+  },
+  {
+    "id": 164,
+    "name": "Marrow Reapers",
+    "note": "\u003cskillId:161\u003e\n\u003coffhandSkillId:164\u003e\n\u003cspeedBoost:5\u003e\n\u003cmaxRefineCount:12\u003e\n\u003cmaxRefinedTraits:5\u003e\n\u003cthisHit:260\u003e\n\u003cthisCri:12\u003e",
+    "description": "It does not bleed and it does not tire, so stop trying to hurt it and take it apart instead.\nSlays beasts, insects, reptiles, and the undead.",
+    "iconIndex": 321,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 16,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 17,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 12,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 11,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      195,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 50000,
+    "animationId": 1,
+    "wtypeId": 17
+  },
+  {
+    "id": 165,
+    "name": "Throat Finders",
+    "note": "\u003cskillId:161\u003e\n\u003coffhandSkillId:164\u003e\n\u003cspeedBoost:5\u003e\n\u003cmaxRefineCount:18\u003e\n\u003cmaxRefinedTraits:7\u003e\n\u003cthisHit:350\u003e\n\u003cthisCri:15\u003e",
+    "description": "Armor covers most of a person. Most is not all, and the rest of it is up near the collar.\nSlays beasts, insects, reptiles, the undead, and humanoids.",
+    "iconIndex": 380,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 16,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 17,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 12,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 11,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 18,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      280,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 200000,
+    "animationId": 1,
+    "wtypeId": 17
+  },
+  {
+    "id": 166,
+    "name": "Godflayers",
+    "note": "\u003cskillId:161\u003e\n\u003coffhandSkillId:164\u003e\n\u003cspeedBoost:5\u003e\n\u003cmaxRefineCount:25\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:450\u003e\n\u003cthisCri:18\u003e",
+    "description": "There is no technique for this. There is only the decision to begin.\nSlays beasts, insects, reptiles, the undead, humanoids, and deities.",
+    "iconIndex": 381,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 16,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 17,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 12,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 11,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 18,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 20,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      380,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 750000,
+    "animationId": 1,
+    "wtypeId": 17
+  },
+  {
+    "id": 167,
+    "name": "\"Brought Down\"",
+    "note": "\u003cskillId:161\u003e\n\u003coffhandSkillId:164\u003e\n\u003cspeedBoost:5\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:120\u003e\n\u003cthisCri:12\u003e",
+    "description": "⭐ It was in the air. It is not in the air now.\nAnnihilates flying foes.",
+    "iconIndex": 376,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      95,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 1,
+    "wtypeId": 17
+  },
+  {
+    "id": 168,
+    "name": "\"Opened Up\"",
+    "note": "\u003cskillId:161\u003e\n\u003coffhandSkillId:164\u003e\n\u003cspeedBoost:5\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:250\u003e\n\u003cthisCri:16\u003e",
+    "description": "⭐⭐ Whatever it was holding shut, it is not holding shut any longer.\nAnnihilates flying and shielded foes.",
+    "iconIndex": 378,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 23,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      220,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 1,
+    "wtypeId": 17
+  },
+  {
+    "id": 169,
+    "name": "\"Nemean's Talons\"",
+    "note": "\u003cskillId:161\u003e\n\u003coffhandSkillId:164\u003e\n\u003cspeedBoost:5\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:380\u003e\n\u003cthisCri:22\u003e",
+    "description": "⭐⭐⭐ Its hide turned aside every blade ever forged. Its own claws did not.\nAnnihilates flying, shielded, and aural foes.",
+    "iconIndex": 379,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 23,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 24,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      430,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 1,
+    "wtypeId": 17
+  },
+  {
+    "id": 170,
+    "name": "\"Sparagmos\"",
+    "note": "\u003cskillId:161\u003e\n\u003coffhandSkillId:164\u003e\n\u003cspeedBoost:5\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:600\u003e\n\u003cthisCri:30\u003e",
+    "description": "Not a technique but a rite, performed with the hands, and performed until it is finished.\nSlays every kind of thing there is.",
+    "iconIndex": 382,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 1,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 16,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 17,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 12,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 11,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 18,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 20,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 22,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 23,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 24,
+        "value": 0
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      0,
+      0,
+      760,
+      0,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 1,
+    "wtypeId": 17
+  },
+  {
+    "id": 171,
+    "name": "Basic Arm",
+    "note": "\u003cskillId:171\u003e\n\u003coffhandSkillId:174\u003e\n\u003cmaxRefineCount:2\u003e\n\u003cmaxRefinedTraits:2\u003e\n\u003cthisHit:20\u003e",
+    "description": "A light mechanical enhancement for your arm, sold as-is and with no warranty.\nDisassembles constructs, may apply \\State[8](10%).",
+    "iconIndex": 106,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      200,
+      0,
+      50,
+      15,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 1000,
+    "animationId": 1,
+    "wtypeId": 18
+  },
+  {
+    "id": 172,
+    "name": "Heavy Arm",
+    "note": "\u003cskillId:171\u003e\n\u003coffhandSkillId:174\u003e\n\u003cmaxRefineCount:5\u003e\n\u003cmaxRefinedTraits:3\u003e\n\u003cthisHit:45\u003e",
+    "description": "Heavier, and therefore better, by the only metric that has ever really mattered.\nDisassembles constructs, may apply \\State[8](10%).",
+    "iconIndex": 106,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      450,
+      0,
+      100,
+      30,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 5000,
+    "animationId": 1,
+    "wtypeId": 18
+  },
+  {
+    "id": 173,
+    "name": "Hydraulic Press",
+    "note": "\u003cskillId:171\u003e\n\u003coffhandSkillId:174\u003e\n\u003cmaxRefineCount:8\u003e\n\u003cmaxRefinedTraits:4\u003e\n\u003cthisHit:75\u003e",
+    "description": "Rated for industrial use, which nobody has ever once interpreted as a restriction.\nDisassembles constructs, may apply \\State[8](10%).",
+    "iconIndex": 106,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      800,
+      0,
+      175,
+      55,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 25000,
+    "animationId": 1,
+    "wtypeId": 18
+  },
+  {
+    "id": 174,
+    "name": "Piledriver",
+    "note": "\u003cskillId:171\u003e\n\u003coffhandSkillId:174\u003e\n\u003cmaxRefineCount:12\u003e\n\u003cmaxRefinedTraits:5\u003e\n\u003cthisHit:110\u003e",
+    "description": "It drives piles. It has never been especially fussy about what counts as a pile.\nDisassembles constructs, may apply \\State[8](10%).",
+    "iconIndex": 106,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      1300,
+      0,
+      280,
+      95,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 100000,
+    "animationId": 1,
+    "wtypeId": 18
+  },
+  {
+    "id": 175,
+    "name": "Demolition Rig",
+    "note": "\u003cskillId:171\u003e\n\u003coffhandSkillId:174\u003e\n\u003cmaxRefineCount:18\u003e\n\u003cmaxRefinedTraits:7\u003e\n\u003cthisHit:150\u003e",
+    "description": "Condemned buildings and condemned people come down in much the same fashion.\nDisassembles constructs, may apply \\State[8](10%).",
+    "iconIndex": 106,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      1900,
+      0,
+      415,
+      145,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 400000,
+    "animationId": 1,
+    "wtypeId": 18
+  },
+  {
+    "id": 176,
+    "name": "Superstructure",
+    "note": "\u003cskillId:171\u003e\n\u003coffhandSkillId:174\u003e\n\u003cmaxRefineCount:25\u003e\n\u003cmaxRefinedTraits:10\u003e\n\u003cthisHit:195\u003e",
+    "description": "At some point the arm stopped being your attachment and you became its.\nDisassembles constructs, may apply \\State[8](10%).",
+    "iconIndex": 106,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.1
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      2600,
+      0,
+      580,
+      210,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 999999,
+    "animationId": 1,
+    "wtypeId": 18
+  },
+  {
+    "id": 177,
+    "name": "\"Meta Arm\"",
+    "note": "\u003cskillId:171\u003e\n\u003coffhandSkillId:174\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:60\u003e\n\u003cstateDurationFlat:30\u003e",
+    "description": "⭐ A cybernetic wonder, preloaded with some tutorials on kicking machine ass.\nDisassembles constructs, may apply \\State[8](25%), lengthens every state you apply by 0.5 seconds.",
+    "iconIndex": 143,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.25
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      600,
+      0,
+      135,
+      40,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 5,
+    "wtypeId": 18
+  },
+  {
+    "id": 178,
+    "name": "\"Sybirtek Arm\"",
+    "note": "\u003cskillId:171\u003e\n\u003coffhandSkillId:174\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:130\u003e\n\u003cstateDurationFlat:60\u003e",
+    "description": "⭐⭐ A mechanical masterpiece, constructed by Sybirtek™ for your combat pleasure.\nDisassembles constructs, may apply \\State[8](25%), lengthens every state you apply by 1 second.",
+    "iconIndex": 143,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.25
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      1600,
+      0,
+      340,
+      115,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 5,
+    "wtypeId": 18
+  },
+  {
+    "id": 179,
+    "name": "\"Talos\"",
+    "note": "\u003cskillId:171\u003e\n\u003coffhandSkillId:174\u003e\n\u003cnotRefinementBase\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:220\u003e\n\u003cstateDurationFlat:90\u003e",
+    "description": "⭐⭐⭐ The bronze sentry of Crete, who killed by taking hold and not letting go.\nDisassembles constructs, may apply \\State[8](25%), lengthens every state you apply by 1.5 seconds.",
+    "iconIndex": 143,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.25
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      3000,
+      0,
+      675,
+      250,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 5,
+    "wtypeId": 18
+  },
+  {
+    "id": 180,
+    "name": "\"Tonnage\"",
+    "note": "\u003cskillId:171\u003e\n\u003coffhandSkillId:174\u003e\n\u003cnotRefinementMaterial\u003e\n\u003cthisHit:280\u003e",
+    "description": "No mechanism, no trick, and no particular hurry about any of it.\nSimply a very great deal of weight, arriving.",
+    "iconIndex": 143,
+    "traits": [
+      {
+        "code": 31,
+        "dataId": 3,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 10,
+        "value": 0
+      },
+      {
+        "code": 31,
+        "dataId": 19,
+        "value": 0
+      },
+      {
+        "code": 32,
+        "dataId": 8,
+        "value": 0.25
+      }
+    ],
+    "etypeId": 1,
+    "params": [
+      3800,
+      0,
+      825,
+      315,
+      0,
+      0,
+      0,
+      0
+    ],
+    "price": 0,
+    "animationId": 5,
+    "wtypeId": 18
+  }
 ]

--- a/chef-adventure/data/config.proficiency.json
+++ b/chef-adventure/data/config.proficiency.json
@@ -2166,27 +2166,6 @@
       "jsRewards": ""
     },
     {
-      "key": "=",
-      "actorIds": [
-        1,
-        2
-      ],
-      "requirements": [
-        {
-          "skillId": 46,
-          "proficiency": 500,
-          "secondarySkillIds": [
-            47,
-            48
-          ]
-        }
-      ],
-      "skillRewards": [
-        49
-      ],
-      "jsRewards": ""
-    },
-    {
       "key": "DEFLECT_PARRY_1",
       "actorIds": [
         1,

--- a/chef-adventure/js/plugins/j/abs/J-ABS.js
+++ b/chef-adventure/js/plugins/j/abs/J-ABS.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v4.15.0 ABS] Enables combat to be carried out on the map.
+ * [v4.16.0 ABS] Enables combat to be carried out on the map.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -48,6 +48,15 @@
  * for JABS lives at the top instead of the bottom.
  *
  * CHANGELOG:
+ * - 4.16.0
+ *    Fixed turnEndOnMap running the engine's own turn-end effects while JABS was
+ *    active and skipping them while it was disabled - the guard was negated, so
+ *    regeneration and poison applied twice under JABS and not at all without it.
+ *    Fixed <noAutoAssignType:[IDS]> never being read; the blacklist was checking
+ *    a J-Passive notetag instead, so equipped passive state ids were blocking
+ *    skill types by numeric coincidence while the documented tag did nothing.
+ *    Moved the passive-state exclusion out of the affliction strip and into
+ *    J-Passive-Conditional, which is where both halves of that question live.
  * - 4.15.0
  *    Added <thisIgnoreParry:N> so a skill can carry its own parry-ignore, and
  *    made <ignoreParry:N> readable from every note source on the attacker rather
@@ -4349,7 +4358,7 @@ J.ABS.Helpers.loadExternalConfig = (configPath = "data/config.jabs.json") => {
 /**
 * The metadata associated with this plugin.
 */
-J.ABS.Metadata = new J_AbsPluginMetadata("J-ABS", "4.15.0");
+J.ABS.Metadata = new J_AbsPluginMetadata("J-ABS", "4.16.0");
 J.ABS.Helpers.loadExternalConfig();
 /**
 * The various default values across the engine. Often configurable.
@@ -23836,9 +23845,6 @@ var StateAfflictionProvider = class StateAfflictionProvider {
 		if (trackedState.stateId === battler.deathStateId()) {
 			return false;
 		}
-		if (J.PASSIVE && battler.isPassiveState(trackedState.stateId) === true) {
-			return false;
-		}
 		return true;
 	}
 };
@@ -23846,7 +23852,7 @@ var StateAfflictionProvider = class StateAfflictionProvider {
 //#endregion
 //#region src/plugins/abs/core/_metadata/meta.js
 var PLUGIN_NAME = "J-ABS";
-var PLUGIN_VERSION = "4.15.0";
+var PLUGIN_VERSION = "4.16.0";
 var PLUGIN_DESC_TAG = "ABS";
 
 //#endregion
@@ -27879,7 +27885,7 @@ Game_Actor.prototype.canAutoAssignSkillOnLevelup = function(skillId) {
 	const onlyUpgradeable = RPGManager.checkForBooleanFromNoteByRegex(skillData, J.ABS.RegExp.UpgradeOnlySkill);
 	if (onlyUpgradeable) return false;
 	const blacklistedBySkillTypeId = objectsToCheck.some((object) => {
-		const skillTypeIds = RPGManager.getNumbersFromNoteByRegex(object, J.PASSIVE.RegExp.EquippedPassiveStateIds);
+		const skillTypeIds = RPGManager.getNumbersFromNoteByRegex(object, J.ABS.RegExp.BlacklistAutoAssignSkillType);
 		if (skillTypeIds.includes(skillData.stypeId)) return true;
 		return false;
 	});
@@ -27934,7 +27940,7 @@ Game_Actor.prototype.performJabsFloorDamage = function() {
 */
 J.ABS.Aliased.Game_Actor.set("turnEndOnMap", Game_Actor.prototype.turnEndOnMap);
 Game_Actor.prototype.turnEndOnMap = function() {
-	if (!$jabsEngine.absEnabled) return;
+	if ($jabsEngine.absEnabled === true) return;
 	J.ABS.Aliased.Game_Actor.get("turnEndOnMap").call(this);
 };
 /**

--- a/chef-adventure/js/plugins/j/abs/ext/J-ABS-Juice.js
+++ b/chef-adventure/js/plugins/j/abs/ext/J-ABS-Juice.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.1.0 ABS-JUICE] Procedural map battler motion juice for JABS (squish, tilt, casting pulse, weapon swing).
+ * [v1.1.1 ABS-JUICE] Procedural map battler motion juice for JABS (squish, tilt, casting pulse, weapon swing).
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -168,6 +168,10 @@
  *
  * ============================================================================
  * CHANGELOG:
+ * - 1.1.1
+ *    Simplified six guards that tested a value for null and undefined before
+ *    asking whether it was finite, which Number.isFinite already answers for
+ *    both. No behavioural change; the checks could never have decided anything.
  * - 1.1.0
  *    Added <noJuice> and <juiceMotion:none> to suppress caster motion outright.
  *    Added flip/flip-reverse caster-body full-rotation spin motions.
@@ -338,7 +342,7 @@ J.ABS.EXT.JUICE = {};
 /**
 * The metadata associated with this plugin.
 */
-J.ABS.EXT.JUICE.Metadata = new JAbsJuice_PluginMetadata("J-ABS-Juice", "1.1.0");
+J.ABS.EXT.JUICE.Metadata = new JAbsJuice_PluginMetadata("J-ABS-Juice", "1.1.1");
 /**
 * A collection of all aliased methods for this plugin.
 */
@@ -398,7 +402,7 @@ J.ABS.EXT.JUICE.RegExp = {
 //#endregion
 //#region src/plugins/abs/ext/juice/_metadata/meta.js
 var PLUGIN_NAME = "J-ABS-Juice";
-var PLUGIN_VERSION = "1.1.0";
+var PLUGIN_VERSION = "1.1.1";
 var PLUGIN_DESC_TAG = "ABS-JUICE";
 
 //#endregion
@@ -939,7 +943,7 @@ var JuiceWeaponSwingMotionEffect = class JuiceWeaponSwingMotionEffect extends Ju
 	* @returns {number}
 	*/
 	static stabBladeRotationRadians(dir, tipAngleRadians) {
-		const tip = tipAngleRadians !== undefined && tipAngleRadians !== null && Number.isFinite(tipAngleRadians) ? tipAngleRadians : JuiceWeaponSwingMotionEffect.StabIconTipAngleRadians;
+		const tip = Number.isFinite(tipAngleRadians) ? tipAngleRadians : JuiceWeaponSwingMotionEffect.StabIconTipAngleRadians;
 		const forward = JuiceWeaponSwingMotionEffect.#forwardUnit(dir);
 		const thrustAngle = Math.atan2(forward.y, forward.x);
 		return thrustAngle - tip;
@@ -1035,8 +1039,8 @@ var JuiceWeaponSwingMotionEffect = class JuiceWeaponSwingMotionEffect extends Ju
 		* Stab tip axis (radians); ignored except stab-forward.
 		* @type {number}
 		*/
-		this._stabTipAngleRadians = stabTipAngleRadians !== undefined && stabTipAngleRadians !== null && Number.isFinite(stabTipAngleRadians) ? stabTipAngleRadians : JuiceWeaponSwingMotionEffect.StabIconTipAngleRadians;
-		if (neutralBaseX !== undefined && neutralBaseX !== null && Number.isFinite(neutralBaseX) && neutralBaseY !== undefined && neutralBaseY !== null && Number.isFinite(neutralBaseY)) {
+		this._stabTipAngleRadians = Number.isFinite(stabTipAngleRadians) ? stabTipAngleRadians : JuiceWeaponSwingMotionEffect.StabIconTipAngleRadians;
+		if (Number.isFinite(neutralBaseX) && Number.isFinite(neutralBaseY)) {
 			this._baseX = neutralBaseX;
 			this._baseY = neutralBaseY;
 		} else {
@@ -1411,7 +1415,7 @@ var JuiceProfileResolver = class JuiceProfileResolver {
 	static resolveJuiceWeaponTipRadians(action, motionKey) {
 		const skill = action.getBaseSkill();
 		const deg = skill.jabsJuiceStabTipDegrees;
-		if (deg !== null && deg !== undefined && Number.isFinite(deg)) {
+		if (Number.isFinite(deg)) {
 			return deg * Math.PI / 180;
 		}
 		if (motionKey === JuiceWeaponSwingMotionEffect.MotionTypes.StabForward || motionKey === JuiceWeaponSwingMotionEffect.MotionTypes.Present) {
@@ -2203,7 +2207,7 @@ var JuiceWeaponSwingOverlay = class JuiceWeaponSwingOverlay {
 	* @returns {number}
 	*/
 	static #coalesceSpinCount(spinCount) {
-		if (spinCount === undefined || spinCount === null || Number.isFinite(spinCount) === false) {
+		if (Number.isFinite(spinCount) === false) {
 			return 1;
 		}
 		return spinCount;
@@ -2296,7 +2300,7 @@ var JuiceWeaponSwingOverlay = class JuiceWeaponSwingOverlay {
 	*/
 	static play(parentSprite, iconIndex, peakRotationRadians, durationFrames, motionType, arcSpanDegrees, swingDirection, weaponTipRadians, spinCount, profileGun) {
 		let spanDeg = arcSpanDegrees;
-		if (spanDeg === undefined || spanDeg === null || Number.isFinite(spanDeg) === false) {
+		if (Number.isFinite(spanDeg) === false) {
 			spanDeg = 120;
 		}
 		const pw = ImageManager.iconWidth;
@@ -2319,7 +2323,7 @@ var JuiceWeaponSwingOverlay = class JuiceWeaponSwingOverlay {
 			swingDir = parentSprite._character.direction();
 		}
 		let weaponTipResolved = weaponTipRadians;
-		if (weaponTipResolved === undefined || weaponTipResolved === null || Number.isFinite(weaponTipResolved) === false) {
+		if (Number.isFinite(weaponTipResolved) === false) {
 			weaponTipResolved = JuiceWeaponSwingMotionEffect.StabIconTipAngleRadians;
 		}
 		const spinCountResolved = JuiceWeaponSwingOverlay.#coalesceSpinCount(spinCount);

--- a/chef-adventure/js/plugins/j/diff/J-Difficulty.js
+++ b/chef-adventure/js/plugins/j/diff/J-Difficulty.js
@@ -2,7 +2,7 @@
  
 /*:
  * @target MZ
- * @plugindesc [v2.1.1 DIFFICULTY] A layered difficulty system.
+ * @plugindesc [v2.1.2 DIFFICULTY] A layered difficulty system.
  * @base J-Base
  * @orderAfter J-Base
  * @author JE
@@ -23,6 +23,12 @@
  * All difficulties are defined in an external JSON file.
  * ============================================================================
  * CHANGELOG:
+ * - 2.1.2
+ *    Difficulty scaling can no longer reduce max hp below one. The engine floors
+ *    it at one inside its own param call, and the difficulty multiplier was
+ *    applied to the result - outside that clamp - so a max hp multiplier of zero
+ *    produced a battler with no maximum hp and broke every ratio computed from
+ *    it. Other parameters still scale to zero, which is a legitimate setting.
  * - 2.1.1
  *    The difficulty points window no longer declares private members. A
  *    window's constructor reaches initialize, and through it the drawing
@@ -843,7 +849,7 @@ J.DIFFICULTY = {};
 /**
 * The `metadata` associated with this plugin, such as version.
 */
-J.DIFFICULTY.Metadata = new J_DiffPluginMetadata("J-Difficulty", "2.1.1");
+J.DIFFICULTY.Metadata = new J_DiffPluginMetadata("J-Difficulty", "2.1.2");
 /**
 * The actual `plugin parameters` extracted from RMMZ.
 */
@@ -1293,7 +1299,8 @@ Game_Actor.prototype.param = function(paramId) {
 	const originalValue = J.DIFFICULTY.Aliased.Game_Actor.get("param").call(this, paramId);
 	const appliedDifficulty = $gameTemp.getAppliedDifficulty();
 	const multiplier = appliedDifficulty.actorEffects.bparams[paramId] / 100;
-	return Math.round(originalValue * multiplier);
+	const scaledValue = Math.round(originalValue * multiplier);
+	return paramId === 0 ? Math.max(1, scaledValue) : scaledValue;
 };
 /**
 * Extends {@link #sparam}.<br/>
@@ -1332,7 +1339,8 @@ Game_Enemy.prototype.param = function(paramId) {
 	const originalValue = J.DIFFICULTY.Aliased.Game_Enemy.get("param").call(this, paramId);
 	const appliedDifficulty = $gameTemp.getAppliedDifficulty();
 	const multiplier = appliedDifficulty.enemyEffects.bparams[paramId] / 100;
-	return Math.round(originalValue * multiplier);
+	const scaledValue = Math.round(originalValue * multiplier);
+	return paramId === 0 ? Math.max(1, scaledValue) : scaledValue;
 };
 /**
 * Extends {@link #sparam}.<br/>

--- a/chef-adventure/js/plugins/j/jafting/ext/J-JAFTING-Creation.js
+++ b/chef-adventure/js/plugins/j/jafting/ext/J-JAFTING-Creation.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.3.0 JAFTING-CREATE] An extension for JAFTING to enable recipe creation.
+ * [v1.3.1 JAFTING-CREATE] An extension for JAFTING to enable recipe creation.
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -154,6 +154,11 @@
  * so retuning an economy is done in the data editor rather than here.
  * ============================================================================
  * CHANGELOG:
+ * - 1.3.1
+ *    Fixed a recipe carrying an SDP cost throwing when J-SDP is not installed.
+ *    The affordability check read the leader's panel points directly, while the
+ *    held-quantity method it duplicates guards that read and answers zero
+ *    without the plugin; it now defers to that method for every component type.
  * - 1.3.0
  *    Added the study shop - Scene_JaftingStudy, its two windows, and
  *    StudyPurchaseService - so recipes can be bought rather than only found.
@@ -577,18 +582,17 @@ var CraftingComponent = class CraftingComponent {
 	}
 	/**
 	* Checks if the party has as many of this component as are required.
+	*
+	* Every kind of component answers this the same way - compare the requirement against what the
+	* party holds - and {@link #getHandledQuantity} is already the one place that knows how to read
+	* "what the party holds" for each kind. Asking it rather than re-deriving the figure per type is
+	* what keeps the two from drifting apart, which they had: the categorical rule that a slot is
+	* filled by exactly one stack lives there, and so does the answer for an SDP cost in a game with
+	* no SDP installed.
 	* @return {boolean}
 	*/
 	hasEnough() {
-		if (this.isCategorical()) return this.#count <= this.getHandledQuantity();
-		if (this.isDatabaseEntry()) {
-			const count = $gameParty.numItems(this.getItem());
-			return this.#count <= count;
-		}
-		if (this.isGold()) {
-			return this.#count <= $gameParty.gold();
-		}
-		return this.#count <= $gameParty.leader().getSdpPoints();
+		return this.#count <= this.getHandledQuantity();
 	}
 	/**
 	* The display label for a categorical slot, such as `Any Meat`.
@@ -1831,7 +1835,7 @@ J.JAFTING.EXT.CREATE = {};
 /**
 * The metadata associated with this plugin.
 */
-J.JAFTING.EXT.CREATE.Metadata = new J_CraftingCreatePluginMetadata("J-JAFTING-Creation", "1.3.0");
+J.JAFTING.EXT.CREATE.Metadata = new J_CraftingCreatePluginMetadata("J-JAFTING-Creation", "1.3.1");
 /**
 * A collection of all aliased methods for this plugin.
 */

--- a/chef-adventure/js/plugins/j/passive/ext/J-Passive-Conditional.js
+++ b/chef-adventure/js/plugins/j/passive/ext/J-Passive-Conditional.js
@@ -2,7 +2,7 @@
 /*:
  * @target MZ
  * @plugindesc
- * [v1.2.0 PASSIVE-CONDITIONAL] Gates passives and auto-applies combat states (JABS map).
+ * [v1.3.0 PASSIVE-CONDITIONAL] Gates passives and auto-applies combat states (JABS map).
  * @author JE
  * @url https://github.com/je-can-code/rmmz-plugins
  * @base J-Base
@@ -311,6 +311,12 @@
  *    Taking even a single step immediately strips it and resets the stand timer.
  * ============================================================================
  * CHANGELOG:
+ * - 1.3.0
+ *    Passive states no longer appear in the JABS affliction strip. A passive is
+ *    permanent and neither waits out nor cures, so listing it beside poison and
+ *    paralysis filled the strip with rows the player could do nothing about.
+ *    This exclusion previously lived in J-ABS, which had to reach across for it;
+ *    it belongs here, where passives and JABS already meet.
  * - 1.2.0
  *    Conditional passive tracking state is no longer written to savefiles
  *    where it can be recomputed from the battler's current situation on load.
@@ -444,7 +450,7 @@ J.PASSIVE.EXT.CONDITIONAL = {};
 /**
 * The metadata associated with this plugin.
 */
-J.PASSIVE.EXT.CONDITIONAL.Metadata = new JPassiveConditional_PluginMetadata("J-Passive-Conditional", "1.2.0");
+J.PASSIVE.EXT.CONDITIONAL.Metadata = new JPassiveConditional_PluginMetadata("J-Passive-Conditional", "1.3.0");
 /**
 * A collection of all aliased methods for this plugin.
 */
@@ -456,6 +462,7 @@ J.PASSIVE.EXT.CONDITIONAL.Aliased.JABS_Action = new Map();
 J.PASSIVE.EXT.CONDITIONAL.Aliased.JABS_Engine = new Map();
 J.PASSIVE.EXT.CONDITIONAL.Aliased.Game_CharacterBase = new Map();
 J.PASSIVE.EXT.CONDITIONAL.Aliased.Window_PassiveDetail = new Map();
+J.PASSIVE.EXT.CONDITIONAL.Aliased.StateAfflictionProvider = new Map();
 /**
 * All regular expressions used by this plugin.
 */
@@ -3050,6 +3057,25 @@ JABS_Action.prototype.preCleanupHook = function() {
 	J.PASSIVE.EXT.CONDITIONAL.Aliased.JABS_Action.get("preCleanupHook").call(this);
 	const casterBattler = this.getCaster().getBattler();
 	SkillResolutionStateRemovalManager.process(casterBattler, this.getBaseSkill().id);
+};
+
+//#endregion
+//#region src/plugins/passive/ext/conditional/models/StateAfflictionProvider.js
+/**
+* Extends {@link StateAfflictionProvider.qualifies}.<br/>
+* Also excludes passive states from the affliction strip.
+*
+* A passive is a permanent trait wearing a state's clothing - granted by equipment or a skill and
+* never expiring - so listing one beside poison and paralysis would fill the strip with rows the
+* player can neither wait out nor cure. J-ABS has no notion of a passive state, and the knowledge
+* belongs on this side of the seam: this extension is where passives and JABS already meet.
+*/
+J.PASSIVE.EXT.CONDITIONAL.Aliased.StateAfflictionProvider.set("qualifies", StateAfflictionProvider.qualifies);
+StateAfflictionProvider.qualifies = function(trackedState, battler) {
+	const qualifiesNormally = J.PASSIVE.EXT.CONDITIONAL.Aliased.StateAfflictionProvider.get("qualifies").call(this, trackedState, battler);
+	if (qualifiesNormally === false) return false;
+	if (battler.isPassiveState(trackedState.stateId) === true) return false;
+	return true;
 };
 
 //#endregion


### PR DESCRIPTION
Rebuilt plugin ships from [rmmz-plugins#75](https://github.com/je-can-code/rmmz-plugins/pull/75), plus in-flight weapon data.

## Plugin sync

Five ships changed source upstream and are rebuilt here:

| ship | version |
|---|---|
| `J-ABS` | 4.15.0 → **4.16.0** |
| `J-Passive-Conditional` | 1.2.0 → **1.3.0** |
| `J-Difficulty` | 2.1.1 → **2.1.2** |
| `J-JAFTING-Creation` | 1.3.0 → **1.3.1** |
| `J-ABS-Juice` | 1.1.0 → **1.1.1** |

**Three alter runtime behaviour and are worth a testplay:**

- **Turn-end effects.** `turnEndOnMap`'s guard was negated, so the engine's own regeneration and poison ran *while JABS was active* and were skipped *while it was disabled*. Since JABS is on in this project, the practical change is that vanilla turn-end effects **stop** applying on top of JABS's own. Anything that felt like it was regenerating or ticking twice is the thing to look at.
- **Max hp floor.** A difficulty can no longer scale max hp below one. Not reachable from current data — all seventeen difficulties use a max hp multiplier of 100 or more — so no live change, but the invariant is now enforced in code rather than by data discipline.
- **SDP costs in crafting.** A recipe carrying an SDP cost no longer throws when J-SDP is absent. J-SDP is installed here, so again no live change.

Two more, both previously inert:

- `<noAutoAssignType:[IDS]>` now actually works. It was reading a J-Passive notetag, so equipped passive **state** ids were blocking skill **types** by numeric coincidence while the documented tag did nothing. **If any actor or class in this project carries `<equippedPassive:[…]>`, its auto-assign behaviour will change** — that was the accidental input.
- Passive states no longer show in the JABS affliction strip. The filter moved from `J-ABS` into `J-Passive-Conditional`; both are installed and enabled, so behaviour here is unchanged.

Upstream that branch also moved the mutation score 85.5% → 90.0% and fixed a tooling defect that was reporting phantom survivors, but none of that reaches this repo.

## Weapon data

Riding along rather than blocking on a separate PR: weapon database expansion, and removal of a proficiency conclusion keyed on a bare `=` that granted skill 49 off skill 46. Authored separately from the plugin work above and kept in its own commit.
